### PR TITLE
New stuff.

### DIFF
--- a/ctangle.c
+++ b/ctangle.c
@@ -1,8 +1,8 @@
 /*1:*/
-#line 66 "ctangle.w"
+#line 66 "./ctangle.w"
 
 /*4:*/
-#line 46 "common.h"
+#line 46 "./common.h"
 
 #include <ctype.h>  
 #include <stdbool.h>  
@@ -13,7 +13,7 @@
 #include <string.h>  
 
 /*:4*/
-#line 67 "ctangle.w"
+#line 67 "./ctangle.w"
 
 #define banner "This is CTANGLE (Version 4.2)" \
 
@@ -141,10 +141,10 @@
 #define app_repl(c) {if(tok_ptr==tok_mem_end) overflow("token") ;*tok_ptr++= c;} \
 
 
-#line 68 "ctangle.w"
+#line 68 "./ctangle.w"
 
 /*3:*/
-#line 37 "common.h"
+#line 37 "./common.h"
 
 typedef bool boolean;
 typedef uint8_t eight_bits;
@@ -153,7 +153,7 @@ extern boolean program;
 extern int phase;
 
 /*:3*//*5:*/
-#line 76 "common.h"
+#line 76 "./common.h"
 
 extern char section_text[];
 extern char*section_text_end;
@@ -161,7 +161,7 @@ extern char*id_first;
 extern char*id_loc;
 
 /*:5*//*6:*/
-#line 94 "common.h"
+#line 94 "./common.h"
 
 extern char buffer[];
 extern char*buffer_end;
@@ -169,7 +169,7 @@ extern char*loc;
 extern char*limit;
 
 /*:6*//*7:*/
-#line 111 "common.h"
+#line 111 "./common.h"
 
 extern int include_depth;
 extern FILE*file[];
@@ -185,7 +185,7 @@ extern boolean changing;
 extern boolean web_file_open;
 
 /*:7*//*9:*/
-#line 131 "common.h"
+#line 131 "./common.h"
 
 extern sixteen_bits section_count;
 extern boolean changed_section[];
@@ -193,7 +193,7 @@ extern boolean change_pending;
 extern boolean print_where;
 
 /*:9*//*10:*/
-#line 145 "common.h"
+#line 145 "./common.h"
 
 typedef struct name_info{
 char*byte_start;
@@ -218,12 +218,12 @@ extern hash_pointer hash_end;
 extern hash_pointer h;
 
 /*:10*//*12:*/
-#line 189 "common.h"
+#line 189 "./common.h"
 
 extern int history;
 
 /*:12*//*14:*/
-#line 205 "common.h"
+#line 205 "./common.h"
 
 extern int argc;
 extern char**argv;
@@ -234,7 +234,7 @@ extern char scn_file_name[];
 extern boolean flags[];
 
 /*:14*//*15:*/
-#line 219 "common.h"
+#line 219 "./common.h"
 
 extern FILE*C_file;
 extern FILE*tex_file;
@@ -243,10 +243,10 @@ extern FILE*scn_file;
 extern FILE*active_file;
 
 /*:15*/
-#line 69 "ctangle.w"
+#line 69 "./ctangle.w"
 
 /*19:*/
-#line 122 "ctangle.w"
+#line 122 "./ctangle.w"
 
 typedef struct{
 eight_bits*tok_start;
@@ -255,7 +255,7 @@ sixteen_bits text_link;
 typedef text*text_pointer;
 
 /*:19*//*31:*/
-#line 273 "ctangle.w"
+#line 273 "./ctangle.w"
 
 typedef struct{
 eight_bits*end_field;
@@ -267,10 +267,10 @@ sixteen_bits section_field;
 typedef output_state*stack_pointer;
 
 /*:31*/
-#line 70 "ctangle.w"
+#line 70 "./ctangle.w"
 
 /*20:*/
-#line 129 "ctangle.w"
+#line 129 "./ctangle.w"
 
 static text text_info[max_texts];
 static text_pointer text_info_end= text_info+max_texts-1;
@@ -280,12 +280,12 @@ static eight_bits*tok_mem_end= tok_mem+max_toks-1;
 static eight_bits*tok_ptr;
 
 /*:20*//*26:*/
-#line 199 "ctangle.w"
+#line 199 "./ctangle.w"
 
 static text_pointer last_unnamed;
 
 /*:26*//*32:*/
-#line 289 "ctangle.w"
+#line 289 "./ctangle.w"
 
 static output_state cur_state;
 
@@ -294,18 +294,18 @@ static stack_pointer stack_end= stack+stack_size;
 static stack_pointer stack_ptr;
 
 /*:32*//*37:*/
-#line 365 "ctangle.w"
+#line 365 "./ctangle.w"
 
 static int cur_val;
 
 /*:37*//*42:*/
-#line 456 "ctangle.w"
+#line 456 "./ctangle.w"
 
 static eight_bits out_state;
 static boolean protect;
 
 /*:42*//*45:*/
-#line 487 "ctangle.w"
+#line 487 "./ctangle.w"
 
 static name_pointer output_files[max_files];
 static name_pointer*cur_out_file,*end_output_files,*an_output_file;
@@ -313,49 +313,49 @@ static char cur_section_name_char;
 static char output_file_name[longest_name+1];
 
 /*:45*//*52:*/
-#line 586 "ctangle.w"
+#line 586 "./ctangle.w"
 
 static boolean output_defs_seen= false;
 
 /*:52*//*57:*/
-#line 698 "ctangle.w"
+#line 698 "./ctangle.w"
 
 static char translit[128][translit_length];
 
 /*:57*//*62:*/
-#line 777 "ctangle.w"
+#line 777 "./ctangle.w"
 
 static eight_bits ccode[256];
 
 /*:62*//*66:*/
-#line 837 "ctangle.w"
+#line 837 "./ctangle.w"
 
 static boolean comment_continues= false;
 
 /*:66*//*68:*/
-#line 874 "ctangle.w"
+#line 874 "./ctangle.w"
 
 static name_pointer cur_section_name;
 static boolean no_where;
 
 /*:68*//*82:*/
-#line 1181 "ctangle.w"
+#line 1190 "./ctangle.w"
 
 static text_pointer cur_text;
 static eight_bits next_control;
 
 /*:82*/
-#line 71 "ctangle.w"
+#line 71 "./ctangle.w"
 
 /*8:*/
-#line 125 "common.h"
+#line 125 "./common.h"
 
 extern boolean get_line(void);
 extern void check_complete(void);
 extern void reset_input(void);
 
 /*:8*//*11:*/
-#line 168 "common.h"
+#line 168 "./common.h"
 
 extern boolean names_match(name_pointer,const char*,size_t,eight_bits);
 extern name_pointer id_lookup(const char*,const char*,char);
@@ -368,7 +368,7 @@ extern void print_section_name(name_pointer);
 extern void sprint_section_name(char*,name_pointer);
 
 /*:11*//*13:*/
-#line 192 "common.h"
+#line 192 "./common.h"
 
 extern int wrap_up(void);
 extern void err_print(const char*);
@@ -376,71 +376,71 @@ extern void fatal(const char*,const char*);
 extern void overflow(const char*);
 
 /*:13*//*16:*/
-#line 227 "common.h"
+#line 227 "./common.h"
 
 extern void common_init(void);
 extern void print_stats(void);
 
 /*:16*//*30:*/
-#line 245 "ctangle.w"
+#line 245 "./ctangle.w"
 static void store_two_bytes(sixteen_bits);
 
 /*:30*//*35:*/
-#line 328 "ctangle.w"
+#line 328 "./ctangle.w"
 
 static void push_level(name_pointer);
 static void pop_level(boolean);
 
 /*:35*//*39:*/
-#line 401 "ctangle.w"
+#line 401 "./ctangle.w"
 static void get_output(void);
 
 /*:39*//*44:*/
-#line 477 "ctangle.w"
+#line 477 "./ctangle.w"
 static void flush_buffer(void);
 
 /*:44*//*49:*/
-#line 553 "ctangle.w"
+#line 553 "./ctangle.w"
 static void phase_two(void);
 
 /*:49*//*53:*/
-#line 589 "ctangle.w"
+#line 589 "./ctangle.w"
 
 static void output_defs(void);
 static void out_char(eight_bits);
 
 /*:53*//*65:*/
-#line 817 "ctangle.w"
+#line 817 "./ctangle.w"
 
 static eight_bits skip_ahead(void);
 static boolean skip_comment(boolean);
 
 /*:65*//*70:*/
-#line 924 "ctangle.w"
+#line 924 "./ctangle.w"
 static eight_bits get_next(void);
 
 /*:70*//*84:*/
-#line 1207 "ctangle.w"
+#line 1216 "./ctangle.w"
 static void scan_repl(eight_bits);
 
 /*:84*//*91:*/
-#line 1378 "ctangle.w"
+#line 1389 "./ctangle.w"
 static void scan_section(void);
 
 /*:91*//*99:*/
-#line 1459 "ctangle.w"
+#line 1470 "./ctangle.w"
 static void phase_one(void);
 
 /*:99*//*101:*/
-#line 1493 "ctangle.w"
+#line 1504 "./ctangle.w"
 static void skip_limbo(void);
 
 /*:101*/
-#line 72 "ctangle.w"
+#line 72 "./ctangle.w"
 
 
 /*:1*//*2:*/
-#line 81 "ctangle.w"
+#line 81 "./ctangle.w"
 
 int main(
 int ac,
@@ -449,28 +449,28 @@ char**av)
 argc= ac;argv= av;
 program= ctangle;
 /*21:*/
-#line 137 "ctangle.w"
+#line 137 "./ctangle.w"
 
 text_info->tok_start= tok_ptr= tok_mem;
 text_ptr= text_info+1;text_ptr->tok_start= tok_mem;
 
 
 /*:21*//*23:*/
-#line 147 "ctangle.w"
+#line 147 "./ctangle.w"
 
 init_node(name_dir);
 
 /*:23*//*27:*/
-#line 202 "ctangle.w"
+#line 202 "./ctangle.w"
 last_unnamed= text_info;text_info->text_link= macro;
 
 /*:27*//*46:*/
-#line 497 "ctangle.w"
+#line 497 "./ctangle.w"
 
 cur_out_file= end_output_files= output_files+max_files;
 
 /*:46*//*58:*/
-#line 701 "ctangle.w"
+#line 701 "./ctangle.w"
 
 {
 int i;
@@ -478,7 +478,7 @@ for(i= 0;i<128;i++)sprintf(translit[i],"X%02X",(unsigned int)(128+i));
 }
 
 /*:58*//*63:*/
-#line 780 "ctangle.w"
+#line 780 "./ctangle.w"
 {
 int c;
 for(c= 0;c<256;c++)ccode[c]= ignore;
@@ -498,11 +498,11 @@ ccode['\'']= ord;
 }
 
 /*:63*//*78:*/
-#line 1103 "ctangle.w"
+#line 1112 "./ctangle.w"
 section_text[0]= ' ';
 
 /*:78*/
-#line 88 "ctangle.w"
+#line 88 "./ctangle.w"
 
 common_init();
 if(show_banner)puts(banner);
@@ -512,7 +512,7 @@ return wrap_up();
 }
 
 /*:2*//*24:*/
-#line 153 "ctangle.w"
+#line 153 "./ctangle.w"
 
 boolean names_match(
 name_pointer p,
@@ -525,7 +525,7 @@ return!strncmp(first,p->byte_start,l);
 }
 
 /*:24*//*25:*/
-#line 169 "ctangle.w"
+#line 169 "./ctangle.w"
 
 void
 init_node(
@@ -537,7 +537,7 @@ void
 init_p(name_pointer p,eight_bits t){(void)p;(void)t;}
 
 /*:25*//*29:*/
-#line 235 "ctangle.w"
+#line 235 "./ctangle.w"
 
 static void
 store_two_bytes(
@@ -549,7 +549,7 @@ if(tok_ptr+2> tok_mem_end)overflow("token");
 }
 
 /*:29*//*34:*/
-#line 313 "ctangle.w"
+#line 313 "./ctangle.w"
 
 static void
 push_level(
@@ -566,7 +566,7 @@ cur_section= 0;
 }
 
 /*:34*//*36:*/
-#line 336 "ctangle.w"
+#line 336 "./ctangle.w"
 
 static void
 pop_level(
@@ -582,7 +582,7 @@ if(stack_ptr> stack)cur_state= *stack_ptr;
 }
 
 /*:36*//*38:*/
-#line 372 "ctangle.w"
+#line 372 "./ctangle.w"
 
 static void
 get_output(void)
@@ -605,7 +605,7 @@ switch(a/024000){
 case 0:cur_val= a;out_char(identifier);break;
 case 1:if(a==output_defs_flag)output_defs();
 else/*40:*/
-#line 406 "ctangle.w"
+#line 406 "./ctangle.w"
 
 {
 a-= 024000;
@@ -619,7 +619,7 @@ goto restart;
 }
 
 /*:40*/
-#line 393 "ctangle.w"
+#line 393 "./ctangle.w"
 
 break;
 default:cur_val= a-050000;if(cur_val> 0)cur_section= cur_val;
@@ -629,7 +629,7 @@ out_char(section_number);
 }
 
 /*:38*//*43:*/
-#line 464 "ctangle.w"
+#line 464 "./ctangle.w"
 
 static void
 flush_buffer(void)
@@ -644,29 +644,29 @@ cur_line++;
 }
 
 /*:43*//*48:*/
-#line 518 "ctangle.w"
+#line 518 "./ctangle.w"
 
 static void
 phase_two(void){
 web_file_open= false;
 cur_line= 1;
 /*33:*/
-#line 302 "ctangle.w"
+#line 302 "./ctangle.w"
 
 stack_ptr= stack+1;cur_name= name_dir;cur_repl= text_info->text_link+text_info;
 cur_byte= cur_repl->tok_start;cur_end= (cur_repl+1)->tok_start;cur_section= 0;
 
 /*:33*/
-#line 523 "ctangle.w"
+#line 523 "./ctangle.w"
 
 /*51:*/
-#line 582 "ctangle.w"
+#line 582 "./ctangle.w"
 
 if(!output_defs_seen)
 output_defs();
 
 /*:51*/
-#line 524 "ctangle.w"
+#line 524 "./ctangle.w"
 
 if(text_info->text_link==macro&&cur_out_file==end_output_files){
 fputs("\n! No program text was specified.",stdout);mark_harmless;
@@ -689,7 +689,7 @@ if(text_info->text_link==macro)goto writeloop;
 while(stack_ptr> stack)get_output();
 flush_buffer();
 writeloop:/*50:*/
-#line 559 "ctangle.w"
+#line 559 "./ctangle.w"
 
 for(an_output_file= end_output_files;an_output_file> cur_out_file;){
 an_output_file--;
@@ -710,7 +710,7 @@ flush_buffer();
 }
 
 /*:50*/
-#line 545 "ctangle.w"
+#line 545 "./ctangle.w"
 
 if(show_happiness){
 if(show_progress)new_line;
@@ -720,7 +720,7 @@ fputs("Done.",stdout);
 }
 
 /*:48*//*54:*/
-#line 596 "ctangle.w"
+#line 596 "./ctangle.w"
 
 static void
 output_defs(void)
@@ -760,7 +760,7 @@ pop_level(false);
 }
 
 /*:54*//*55:*/
-#line 639 "ctangle.w"
+#line 639 "./ctangle.w"
 
 static void
 out_char(
@@ -773,7 +773,7 @@ case'\n':if(protect&&out_state!=verbatim)C_putc(' ');
 if(protect||out_state==verbatim)C_putc('\\');
 flush_buffer();if(out_state!=verbatim)out_state= normal;break;
 /*59:*/
-#line 707 "ctangle.w"
+#line 707 "./ctangle.w"
 
 case identifier:
 if(out_state==num_or_id)C_putc(' ');
@@ -788,10 +788,10 @@ j++;
 out_state= num_or_id;break;
 
 /*:59*/
-#line 650 "ctangle.w"
+#line 650 "./ctangle.w"
 
 /*60:*/
-#line 720 "ctangle.w"
+#line 720 "./ctangle.w"
 
 case section_number:
 if(cur_val> 0)C_printf("/*%d:*/",cur_val);
@@ -818,10 +818,10 @@ C_putc('"');C_putc('\n');
 break;
 
 /*:60*/
-#line 651 "ctangle.w"
+#line 651 "./ctangle.w"
 
 /*56:*/
-#line 669 "ctangle.w"
+#line 669 "./ctangle.w"
 
 case plus_plus:C_putc('+');C_putc('+');out_state= normal;break;
 case minus_minus:C_putc('-');C_putc('-');out_state= normal;break;
@@ -842,7 +842,7 @@ case minus_gt_ast:C_putc('-');C_putc('>');C_putc('*');out_state= normal;
 break;
 
 /*:56*/
-#line 652 "ctangle.w"
+#line 652 "./ctangle.w"
 
 case'=':case'>':C_putc(cur_char);C_putc(' ');
 out_state= normal;break;
@@ -861,7 +861,7 @@ default:C_putc(cur_char);out_state= normal;break;
 }
 
 /*:55*//*64:*/
-#line 801 "ctangle.w"
+#line 801 "./ctangle.w"
 
 static eight_bits
 skip_ahead(void)
@@ -879,7 +879,7 @@ if(c!=ignore||*(loc-1)=='>')return c;
 }
 
 /*:64*//*67:*/
-#line 840 "ctangle.w"
+#line 840 "./ctangle.w"
 
 static boolean skip_comment(
 boolean is_long_comment)
@@ -913,7 +913,7 @@ else loc++;
 }
 
 /*:67*//*69:*/
-#line 881 "ctangle.w"
+#line 881 "./ctangle.w"
 
 static eight_bits
 get_next(void)
@@ -927,7 +927,7 @@ if(get_line()==false)return new_section;
 else if(print_where&&!no_where){
 print_where= false;
 /*85:*/
-#line 1213 "ctangle.w"
+#line 1222 "./ctangle.w"
 
 store_two_bytes(0150000);
 if(changing&&include_depth==change_depth){
@@ -942,7 +942,7 @@ id_loc= id_first+strlen(id_first);
 app_repl(a_l%0400);}
 
 /*:85*/
-#line 893 "ctangle.w"
+#line 893 "./ctangle.w"
 
 }
 else return'\n';
@@ -956,23 +956,32 @@ else continue;
 }
 loc++;
 if(xisdigit(c)||c=='.')/*73:*/
-#line 962 "ctangle.w"
+#line 962 "./ctangle.w"
 {
+boolean hex_flag= false;
 id_first= loc-1;
 if(*id_first=='.'&&!xisdigit(*loc))goto mistake;
 if(*id_first=='0'){
 if(*loc=='x'||*loc=='X'){
-loc++;while(xisxdigit(*loc))loc++;goto found;
+hex_flag= true;
+loc++;while(xisxdigit(*loc)||*loc=='\'')loc++;
+}
+else if(*loc=='b'||*loc=='B'){
+loc++;while(*loc=='0'||*loc=='1'||*loc=='\'')loc++;goto found;
 }
 }
-while(xisdigit(*loc))loc++;
+while(xisdigit(*loc)||*loc=='\'')loc++;
 if(*loc=='.'){
 loc++;
-while(xisdigit(*loc))loc++;
+while((hex_flag&&xisxdigit(*loc))||xisdigit(*loc)||*loc=='\'')loc++;
 }
 if(*loc=='e'||*loc=='E'){
 if(*++loc=='+'||*loc=='-')loc++;
-while(xisdigit(*loc))loc++;
+while(xisdigit(*loc)||*loc=='\'')loc++;
+}
+else if(hex_flag&&(*loc=='p'||*loc=='P')){
+if(*++loc=='+'||*loc=='-')loc++;
+while(xisxdigit(*loc)||*loc=='\'')loc++;
 }
 found:while(*loc=='u'||*loc=='U'||*loc=='l'||*loc=='L'
 ||*loc=='f'||*loc=='F')loc++;
@@ -981,13 +990,13 @@ return constant;
 }
 
 /*:73*/
-#line 905 "ctangle.w"
+#line 905 "./ctangle.w"
 
 else if(c=='\''||c=='"'
 ||((c=='L'||c=='u'||c=='U')&&(*loc=='\''||*loc=='"'))
 ||((c=='u'&&*loc=='8')&&(*(loc+1)=='\''||*(loc+1)=='"')))
 /*74:*/
-#line 990 "ctangle.w"
+#line 999 "./ctangle.w"
 {
 char delim= c;
 id_first= section_text+1;
@@ -1031,11 +1040,11 @@ return string;
 }
 
 /*:74*/
-#line 909 "ctangle.w"
+#line 909 "./ctangle.w"
 
 else if(isalpha(c)||isxalpha(c)||ishigh(c))
 /*72:*/
-#line 955 "ctangle.w"
+#line 955 "./ctangle.w"
 {
 id_first= --loc;
 while(isalpha((eight_bits)*++loc)||isdigit((eight_bits)*loc)
@@ -1044,10 +1053,10 @@ id_loc= loc;return identifier;
 }
 
 /*:72*/
-#line 911 "ctangle.w"
+#line 911 "./ctangle.w"
 
 else if(c=='@')/*75:*/
-#line 1035 "ctangle.w"
+#line 1044 "./ctangle.w"
 {
 c= ccode[(eight_bits)*loc++];
 switch(c){
@@ -1063,11 +1072,11 @@ continue;
 case section_name:
 cur_section_name_char= *(loc-1);
 /*77:*/
-#line 1083 "ctangle.w"
+#line 1092 "./ctangle.w"
 {
 char*k;
 /*79:*/
-#line 1105 "ctangle.w"
+#line 1114 "./ctangle.w"
 
 k= section_text;
 while(true){
@@ -1078,7 +1087,7 @@ loc= buffer+1;break;
 }
 c= *loc;
 /*80:*/
-#line 1129 "ctangle.w"
+#line 1138 "./ctangle.w"
 
 if(c=='@'){
 c= *(loc+1);
@@ -1097,7 +1106,7 @@ err_print("! Nesting of section names not allowed");break;
 }
 
 /*:80*/
-#line 1114 "ctangle.w"
+#line 1123 "./ctangle.w"
 
 loc++;if(k<section_text_end)k++;
 if(xisspace(c)){
@@ -1114,7 +1123,7 @@ printf("...");mark_harmless;
 if(*k==' '&&k> section_text)k--;
 
 /*:79*/
-#line 1085 "ctangle.w"
+#line 1094 "./ctangle.w"
 
 if(k-section_text> 3&&strncmp(k-2,"...",3)==0)
 cur_section_name= section_lookup(section_text+1,k-3,true);
@@ -1123,7 +1132,7 @@ else cur_section_name= section_lookup(section_text+1,k,false);
 
 if(cur_section_name_char=='(')
 /*47:*/
-#line 501 "ctangle.w"
+#line 501 "./ctangle.w"
 
 {
 for(an_output_file= cur_out_file;
@@ -1139,16 +1148,16 @@ overflow("output files");
 }
 
 /*:47*/
-#line 1093 "ctangle.w"
+#line 1102 "./ctangle.w"
 
 return section_name;
 }
 
 /*:77*/
-#line 1049 "ctangle.w"
+#line 1058 "./ctangle.w"
 
 case string:/*81:*/
-#line 1151 "ctangle.w"
+#line 1160 "./ctangle.w"
 {
 id_first= loc++;*(limit+1)= '@';*(limit+2)= '>';
 while(*loc!='@'||*(loc+1)!='>')loc++;
@@ -1159,10 +1168,10 @@ return string;
 }
 
 /*:81*/
-#line 1050 "ctangle.w"
+#line 1059 "./ctangle.w"
 
 case ord:/*76:*/
-#line 1062 "ctangle.w"
+#line 1071 "./ctangle.w"
 
 id_first= loc;
 if(*loc=='\\'){
@@ -1185,14 +1194,14 @@ loc++;
 return ord;
 
 /*:76*/
-#line 1051 "ctangle.w"
+#line 1060 "./ctangle.w"
 
 default:return c;
 }
 }
 
 /*:75*/
-#line 912 "ctangle.w"
+#line 912 "./ctangle.w"
 
 else if(xisspace(c)){
 if(!preprocessing||loc> limit)continue;
@@ -1201,7 +1210,7 @@ else return' ';
 }
 else if(c=='#'&&loc==buffer+1)preprocessing= true;
 mistake:/*71:*/
-#line 933 "ctangle.w"
+#line 933 "./ctangle.w"
 
 switch(c){
 case'+':if(*loc=='+')compress(plus_plus);break;
@@ -1225,14 +1234,14 @@ case'!':if(*loc=='=')compress(non_eq);break;
 }
 
 /*:71*/
-#line 919 "ctangle.w"
+#line 919 "./ctangle.w"
 
 return c;
 }
 }
 
 /*:69*//*83:*/
-#line 1185 "ctangle.w"
+#line 1194 "./ctangle.w"
 
 static void
 scan_repl(
@@ -1240,7 +1249,7 @@ eight_bits t)
 {
 sixteen_bits a;
 if(t==section_name){/*85:*/
-#line 1213 "ctangle.w"
+#line 1222 "./ctangle.w"
 
 store_two_bytes(0150000);
 if(changing&&include_depth==change_depth){
@@ -1255,11 +1264,11 @@ id_loc= id_first+strlen(id_first);
 app_repl(a_l%0400);}
 
 /*:85*/
-#line 1191 "ctangle.w"
+#line 1200 "./ctangle.w"
 }
 while(true)switch(a= get_next()){
 /*86:*/
-#line 1226 "ctangle.w"
+#line 1235 "./ctangle.w"
 
 case identifier:a= id_lookup(id_first,id_loc,0)-name_dir;
 app_repl((a/0400)+0200);
@@ -1267,7 +1276,7 @@ app_repl(a%0400);break;
 case section_name:if(t!=section_name)goto done;
 else{
 /*87:*/
-#line 1259 "ctangle.w"
+#line 1268 "./ctangle.w"
 {
 char*try_loc= loc;
 while(*try_loc==' '&&try_loc<limit)try_loc++;
@@ -1280,13 +1289,13 @@ if(*try_loc=='=')err_print("! Missing `@ ' before a named section");
 }
 
 /*:87*/
-#line 1232 "ctangle.w"
+#line 1241 "./ctangle.w"
 
 a= cur_section_name-name_dir;
 app_repl((a/0400)+0250);
 app_repl(a%0400);
 /*85:*/
-#line 1213 "ctangle.w"
+#line 1222 "./ctangle.w"
 
 store_two_bytes(0150000);
 if(changing&&include_depth==change_depth){
@@ -1301,7 +1310,7 @@ id_loc= id_first+strlen(id_first);
 app_repl(a_l%0400);}
 
 /*:85*/
-#line 1236 "ctangle.w"
+#line 1245 "./ctangle.w"
 break;
 }
 case output_defs_code:if(t!=section_name)err_print("! Misplaced @h");
@@ -1312,7 +1321,7 @@ a= output_defs_flag;
 app_repl((a/0400)+0200);
 app_repl(a%0400);
 /*85:*/
-#line 1213 "ctangle.w"
+#line 1222 "./ctangle.w"
 
 store_two_bytes(0150000);
 if(changing&&include_depth==change_depth){
@@ -1327,13 +1336,13 @@ id_loc= id_first+strlen(id_first);
 app_repl(a_l%0400);}
 
 /*:85*/
-#line 1245 "ctangle.w"
+#line 1254 "./ctangle.w"
 
 }
 break;
 case constant:case string:
 /*88:*/
-#line 1270 "ctangle.w"
+#line 1279 "./ctangle.w"
 
 app_repl(a);
 while(id_first<id_loc){
@@ -1342,16 +1351,18 @@ if(*(id_first+1)=='@')id_first++;
 else err_print("! Double @ should be used in string");
 
 }
+else if(a==constant&&*id_first=='\''&&flags['q'])
+id_first++;
 app_repl(*id_first++);
 }
 app_repl(a);break;
 
 /*:88*/
-#line 1249 "ctangle.w"
+#line 1258 "./ctangle.w"
 
 case ord:
 /*89:*/
-#line 1286 "ctangle.w"
+#line 1297 "./ctangle.w"
 {
 int c= (eight_bits)*id_first;
 if(c=='\\'){
@@ -1402,7 +1413,7 @@ app_repl(constant);
 break;
 
 /*:89*/
-#line 1251 "ctangle.w"
+#line 1260 "./ctangle.w"
 
 case definition:case format_code:case begin_C:if(t!=section_name)goto done;
 else{
@@ -1412,7 +1423,7 @@ err_print("! @d, @f and @c are ignored in C text");continue;
 case new_section:goto done;
 
 /*:86*/
-#line 1196 "ctangle.w"
+#line 1205 "./ctangle.w"
 
 case')':app_repl(a);
 if(t==macro)app_repl(' ');
@@ -1425,7 +1436,7 @@ cur_text= text_ptr;(++text_ptr)->tok_start= tok_ptr;
 }
 
 /*:83*//*90:*/
-#line 1345 "ctangle.w"
+#line 1356 "./ctangle.w"
 
 static void
 scan_section(void)
@@ -1440,7 +1451,7 @@ printf("*%d",section_count);update_terminal;
 next_control= 0;
 while(true){
 /*92:*/
-#line 1386 "ctangle.w"
+#line 1397 "./ctangle.w"
 
 while(next_control<definition)
 
@@ -1449,11 +1460,11 @@ loc-= 2;next_control= get_next();
 }
 
 /*:92*/
-#line 1359 "ctangle.w"
+#line 1370 "./ctangle.w"
 
 if(next_control==definition){
 /*93:*/
-#line 1393 "ctangle.w"
+#line 1404 "./ctangle.w"
 {
 while((next_control= get_next())=='\n');
 if(next_control!=identifier){
@@ -1472,7 +1483,7 @@ cur_text->text_link= macro;
 }
 
 /*:93*/
-#line 1361 "ctangle.w"
+#line 1372 "./ctangle.w"
 
 continue;
 }
@@ -1482,14 +1493,14 @@ p= name_dir;break;
 if(next_control==section_name){
 p= cur_section_name;
 /*94:*/
-#line 1418 "ctangle.w"
+#line 1429 "./ctangle.w"
 
 while((next_control= get_next())=='+');
 if(next_control!='='&&next_control!=eq_eq)
 continue;
 
 /*:94*/
-#line 1369 "ctangle.w"
+#line 1380 "./ctangle.w"
 
 break;
 }
@@ -1497,20 +1508,20 @@ return;
 }
 no_where= print_where= false;
 /*95:*/
-#line 1423 "ctangle.w"
+#line 1434 "./ctangle.w"
 
 /*96:*/
-#line 1428 "ctangle.w"
+#line 1439 "./ctangle.w"
 
 store_two_bytes((sixteen_bits)(0150000+section_count));
 
 
 /*:96*/
-#line 1424 "ctangle.w"
+#line 1435 "./ctangle.w"
 
 scan_repl(section_name);
 /*97:*/
-#line 1432 "ctangle.w"
+#line 1443 "./ctangle.w"
 
 if(p==name_dir||p==NULL){
 (last_unnamed)->text_link= cur_text-text_info;last_unnamed= cur_text;
@@ -1527,16 +1538,16 @@ cur_text->text_link= section_flag;
 
 
 /*:97*/
-#line 1426 "ctangle.w"
+#line 1437 "./ctangle.w"
 
 
 /*:95*/
-#line 1375 "ctangle.w"
+#line 1386 "./ctangle.w"
 
 }
 
 /*:90*//*98:*/
-#line 1447 "ctangle.w"
+#line 1458 "./ctangle.w"
 
 static void
 phase_one(void){
@@ -1550,7 +1561,7 @@ phase= 2;
 }
 
 /*:98*//*100:*/
-#line 1464 "ctangle.w"
+#line 1475 "./ctangle.w"
 
 static void
 skip_limbo(void)
@@ -1565,7 +1576,7 @@ c= *loc++;
 if(ccode[(eight_bits)c]==new_section)break;
 switch(ccode[(eight_bits)c]){
 case translit_code:/*102:*/
-#line 1495 "ctangle.w"
+#line 1506 "./ctangle.w"
 
 while(xisspace(*loc)&&loc<limit)loc++;
 loc+= 3;
@@ -1590,7 +1601,7 @@ translit[i-0200][loc-beg]= '\0';
 }
 
 /*:102*/
-#line 1477 "ctangle.w"
+#line 1488 "./ctangle.w"
 break;
 case format_code:case'@':break;
 case control_text:if(c=='q'||c=='Q'){
@@ -1608,7 +1619,7 @@ default:err_print("! Double @ should be used in limbo");
 }
 
 /*:100*//*103:*/
-#line 1521 "ctangle.w"
+#line 1532 "./ctangle.w"
 
 void
 print_stats(void){

--- a/ctangle.c
+++ b/ctangle.c
@@ -1,6 +1,8 @@
 /*1:*/
+#line 66 "ctangle.w"
 
 /*4:*/
+#line 46 "common.h"
 
 #include <ctype.h>  
 #include <stdbool.h>  
@@ -11,6 +13,7 @@
 #include <string.h>  
 
 /*:4*/
+#line 67 "ctangle.w"
 
 #define banner "This is CTANGLE (Version 4.2)" \
 
@@ -140,8 +143,10 @@
 #define skip_digit_separators flags['k'] \
 
 
+#line 68 "ctangle.w"
 
 /*3:*/
+#line 37 "common.h"
 
 typedef bool boolean;
 typedef uint8_t eight_bits;
@@ -150,6 +155,7 @@ extern boolean program;
 extern int phase;
 
 /*:3*//*5:*/
+#line 76 "common.h"
 
 extern char section_text[];
 extern char*section_text_end;
@@ -157,6 +163,7 @@ extern char*id_first;
 extern char*id_loc;
 
 /*:5*//*6:*/
+#line 94 "common.h"
 
 extern char buffer[];
 extern char*buffer_end;
@@ -164,6 +171,7 @@ extern char*loc;
 extern char*limit;
 
 /*:6*//*7:*/
+#line 111 "common.h"
 
 extern int include_depth;
 extern FILE*file[];
@@ -179,6 +187,7 @@ extern boolean changing;
 extern boolean web_file_open;
 
 /*:7*//*9:*/
+#line 131 "common.h"
 
 extern sixteen_bits section_count;
 extern boolean changed_section[];
@@ -186,6 +195,7 @@ extern boolean change_pending;
 extern boolean print_where;
 
 /*:9*//*10:*/
+#line 145 "common.h"
 
 typedef struct name_info{
 char*byte_start;
@@ -210,10 +220,12 @@ extern hash_pointer hash_end;
 extern hash_pointer h;
 
 /*:10*//*12:*/
+#line 189 "common.h"
 
 extern int history;
 
 /*:12*//*14:*/
+#line 205 "common.h"
 
 extern int argc;
 extern char**argv;
@@ -224,6 +236,7 @@ extern char scn_file_name[];
 extern boolean flags[];
 
 /*:14*//*15:*/
+#line 219 "common.h"
 
 extern FILE*C_file;
 extern FILE*tex_file;
@@ -232,8 +245,10 @@ extern FILE*scn_file;
 extern FILE*active_file;
 
 /*:15*/
+#line 69 "ctangle.w"
 
 /*19:*/
+#line 122 "ctangle.w"
 
 typedef struct{
 eight_bits*tok_start;
@@ -242,6 +257,7 @@ sixteen_bits text_link;
 typedef text*text_pointer;
 
 /*:19*//*31:*/
+#line 273 "ctangle.w"
 
 typedef struct{
 eight_bits*end_field;
@@ -253,8 +269,10 @@ sixteen_bits section_field;
 typedef output_state*stack_pointer;
 
 /*:31*/
+#line 70 "ctangle.w"
 
 /*20:*/
+#line 129 "ctangle.w"
 
 static text text_info[max_texts];
 static text_pointer text_info_end= text_info+max_texts-1;
@@ -264,10 +282,12 @@ static eight_bits*tok_mem_end= tok_mem+max_toks-1;
 static eight_bits*tok_ptr;
 
 /*:20*//*26:*/
+#line 199 "ctangle.w"
 
 static text_pointer last_unnamed;
 
 /*:26*//*32:*/
+#line 289 "ctangle.w"
 
 static output_state cur_state;
 
@@ -276,15 +296,18 @@ static stack_pointer stack_end= stack+stack_size;
 static stack_pointer stack_ptr;
 
 /*:32*//*37:*/
+#line 365 "ctangle.w"
 
 static int cur_val;
 
 /*:37*//*42:*/
+#line 456 "ctangle.w"
 
 static eight_bits out_state;
 static boolean protect;
 
 /*:42*//*45:*/
+#line 487 "ctangle.w"
 
 static name_pointer output_files[max_files];
 static name_pointer*cur_out_file,*end_output_files,*an_output_file;
@@ -292,22 +315,27 @@ static char cur_section_name_char;
 static char output_file_name[longest_name+1];
 
 /*:45*//*52:*/
+#line 586 "ctangle.w"
 
 static boolean output_defs_seen= false;
 
 /*:52*//*57:*/
+#line 698 "ctangle.w"
 
 static char translit[128][translit_length];
 
 /*:57*//*62:*/
+#line 777 "ctangle.w"
 
 static eight_bits ccode[256];
 
 /*:62*//*66:*/
+#line 837 "ctangle.w"
 
 static boolean comment_continues= false;
 
 /*:66*//*68:*/
+#line 874 "ctangle.w"
 
 static name_pointer cur_section_name;
 static boolean no_where;
@@ -319,14 +347,17 @@ static text_pointer cur_text;
 static eight_bits next_control;
 
 /*:82*/
+#line 71 "ctangle.w"
 
 /*8:*/
+#line 125 "common.h"
 
 extern boolean get_line(void);
 extern void check_complete(void);
 extern void reset_input(void);
 
 /*:8*//*11:*/
+#line 168 "common.h"
 
 extern boolean names_match(name_pointer,const char*,size_t,eight_bits);
 extern name_pointer id_lookup(const char*,const char*,char);
@@ -339,6 +370,7 @@ extern void print_section_name(name_pointer);
 extern void sprint_section_name(char*,name_pointer);
 
 /*:11*//*13:*/
+#line 192 "common.h"
 
 extern int wrap_up(void);
 extern void err_print(const char*);
@@ -346,38 +378,47 @@ extern void fatal(const char*,const char*);
 extern void overflow(const char*);
 
 /*:13*//*16:*/
+#line 227 "common.h"
 
 extern void common_init(void);
 extern void print_stats(void);
 
 /*:16*//*30:*/
+#line 245 "ctangle.w"
 static void store_two_bytes(sixteen_bits);
 
 /*:30*//*35:*/
+#line 328 "ctangle.w"
 
 static void push_level(name_pointer);
 static void pop_level(boolean);
 
 /*:35*//*39:*/
+#line 401 "ctangle.w"
 static void get_output(void);
 
 /*:39*//*44:*/
+#line 477 "ctangle.w"
 static void flush_buffer(void);
 
 /*:44*//*49:*/
+#line 553 "ctangle.w"
 static void phase_two(void);
 
 /*:49*//*53:*/
+#line 589 "ctangle.w"
 
 static void output_defs(void);
 static void out_char(eight_bits);
 
 /*:53*//*65:*/
+#line 817 "ctangle.w"
 
 static eight_bits skip_ahead(void);
 static boolean skip_comment(boolean);
 
 /*:65*//*70:*/
+#line 924 "ctangle.w"
 static eight_bits get_next(void);
 
 /*:70*//*84:*/
@@ -394,21 +435,14 @@ static void phase_one(void);
 
 /*:99*//*101:*/
 #line 1511 "ctangle.w"
-static void scan_repl(eight_bits);
-
-/*:84*//*91:*/
-static void scan_section(void);
-
-/*:91*//*99:*/
-static void phase_one(void);
-
-/*:99*//*101:*/
 static void skip_limbo(void);
 
 /*:101*/
+#line 72 "ctangle.w"
 
 
 /*:1*//*2:*/
+#line 81 "ctangle.w"
 
 int main(
 int ac,
@@ -417,23 +451,28 @@ char**av)
 argc= ac;argv= av;
 program= ctangle;
 /*21:*/
+#line 137 "ctangle.w"
 
 text_info->tok_start= tok_ptr= tok_mem;
 text_ptr= text_info+1;text_ptr->tok_start= tok_mem;
 
 
 /*:21*//*23:*/
+#line 147 "ctangle.w"
 
 init_node(name_dir);
 
 /*:23*//*27:*/
+#line 202 "ctangle.w"
 last_unnamed= text_info;text_info->text_link= macro;
 
 /*:27*//*46:*/
+#line 497 "ctangle.w"
 
 cur_out_file= end_output_files= output_files+max_files;
 
 /*:46*//*58:*/
+#line 701 "ctangle.w"
 
 {
 int i;
@@ -441,6 +480,7 @@ for(i= 0;i<128;i++)sprintf(translit[i],"X%02X",(unsigned int)(128+i));
 }
 
 /*:58*//*63:*/
+#line 780 "ctangle.w"
 {
 int c;
 for(c= 0;c<256;c++)ccode[c]= ignore;
@@ -464,6 +504,7 @@ ccode['\'']= ord;
 section_text[0]= ' ';
 
 /*:78*/
+#line 88 "ctangle.w"
 
 common_init();
 if(show_banner)puts(banner);
@@ -473,6 +514,7 @@ return wrap_up();
 }
 
 /*:2*//*24:*/
+#line 153 "ctangle.w"
 
 boolean names_match(
 name_pointer p,
@@ -485,6 +527,7 @@ return!strncmp(first,p->byte_start,l);
 }
 
 /*:24*//*25:*/
+#line 169 "ctangle.w"
 
 void
 init_node(
@@ -496,6 +539,7 @@ void
 init_p(name_pointer p,eight_bits t){(void)p;(void)t;}
 
 /*:25*//*29:*/
+#line 235 "ctangle.w"
 
 static void
 store_two_bytes(
@@ -507,6 +551,7 @@ if(tok_ptr+2> tok_mem_end)overflow("token");
 }
 
 /*:29*//*34:*/
+#line 313 "ctangle.w"
 
 static void
 push_level(
@@ -523,6 +568,7 @@ cur_section= 0;
 }
 
 /*:34*//*36:*/
+#line 336 "ctangle.w"
 
 static void
 pop_level(
@@ -538,6 +584,7 @@ if(stack_ptr> stack)cur_state= *stack_ptr;
 }
 
 /*:36*//*38:*/
+#line 372 "ctangle.w"
 
 static void
 get_output(void)
@@ -560,6 +607,7 @@ switch(a/024000){
 case 0:cur_val= a;out_char(identifier);break;
 case 1:if(a==output_defs_flag)output_defs();
 else/*40:*/
+#line 406 "ctangle.w"
 
 {
 a-= 024000;
@@ -573,6 +621,7 @@ goto restart;
 }
 
 /*:40*/
+#line 393 "ctangle.w"
 
 break;
 default:cur_val= a-050000;if(cur_val> 0)cur_section= cur_val;
@@ -582,6 +631,7 @@ out_char(section_number);
 }
 
 /*:38*//*43:*/
+#line 464 "ctangle.w"
 
 static void
 flush_buffer(void)
@@ -596,24 +646,29 @@ cur_line++;
 }
 
 /*:43*//*48:*/
+#line 518 "ctangle.w"
 
 static void
 phase_two(void){
 web_file_open= false;
 cur_line= 1;
 /*33:*/
+#line 302 "ctangle.w"
 
 stack_ptr= stack+1;cur_name= name_dir;cur_repl= text_info->text_link+text_info;
 cur_byte= cur_repl->tok_start;cur_end= (cur_repl+1)->tok_start;cur_section= 0;
 
 /*:33*/
+#line 523 "ctangle.w"
 
 /*51:*/
+#line 582 "ctangle.w"
 
 if(!output_defs_seen)
 output_defs();
 
 /*:51*/
+#line 524 "ctangle.w"
 
 if(text_info->text_link==macro&&cur_out_file==end_output_files){
 fputs("\n! No program text was specified.",stdout);mark_harmless;
@@ -636,6 +691,7 @@ if(text_info->text_link==macro)goto writeloop;
 while(stack_ptr> stack)get_output();
 flush_buffer();
 writeloop:/*50:*/
+#line 559 "ctangle.w"
 
 for(an_output_file= end_output_files;an_output_file> cur_out_file;){
 an_output_file--;
@@ -656,6 +712,7 @@ flush_buffer();
 }
 
 /*:50*/
+#line 545 "ctangle.w"
 
 if(show_happiness){
 if(show_progress)new_line;
@@ -665,6 +722,7 @@ fputs("Done.",stdout);
 }
 
 /*:48*//*54:*/
+#line 596 "ctangle.w"
 
 static void
 output_defs(void)
@@ -704,6 +762,7 @@ pop_level(false);
 }
 
 /*:54*//*55:*/
+#line 639 "ctangle.w"
 
 static void
 out_char(
@@ -716,6 +775,7 @@ case'\n':if(protect&&out_state!=verbatim)C_putc(' ');
 if(protect||out_state==verbatim)C_putc('\\');
 flush_buffer();if(out_state!=verbatim)out_state= normal;break;
 /*59:*/
+#line 707 "ctangle.w"
 
 case identifier:
 if(out_state==num_or_id)C_putc(' ');
@@ -730,8 +790,10 @@ j++;
 out_state= num_or_id;break;
 
 /*:59*/
+#line 650 "ctangle.w"
 
 /*60:*/
+#line 720 "ctangle.w"
 
 case section_number:
 if(cur_val> 0)C_printf("/*%d:*/",cur_val);
@@ -758,8 +820,10 @@ C_putc('"');C_putc('\n');
 break;
 
 /*:60*/
+#line 651 "ctangle.w"
 
 /*56:*/
+#line 669 "ctangle.w"
 
 case plus_plus:C_putc('+');C_putc('+');out_state= normal;break;
 case minus_minus:C_putc('-');C_putc('-');out_state= normal;break;
@@ -780,6 +844,7 @@ case minus_gt_ast:C_putc('-');C_putc('>');C_putc('*');out_state= normal;
 break;
 
 /*:56*/
+#line 652 "ctangle.w"
 
 case'=':case'>':C_putc(cur_char);C_putc(' ');
 out_state= normal;break;
@@ -798,6 +863,7 @@ default:C_putc(cur_char);out_state= normal;break;
 }
 
 /*:55*//*64:*/
+#line 801 "ctangle.w"
 
 static eight_bits
 skip_ahead(void)
@@ -815,6 +881,7 @@ if(c!=ignore||*(loc-1)=='>')return c;
 }
 
 /*:64*//*67:*/
+#line 840 "ctangle.w"
 
 static boolean skip_comment(
 boolean is_long_comment)
@@ -848,6 +915,7 @@ else loc++;
 }
 
 /*:67*//*69:*/
+#line 881 "ctangle.w"
 
 static eight_bits
 get_next(void)
@@ -876,6 +944,7 @@ id_loc= id_first+strlen(id_first);
 app_repl(a_l%0400);}
 
 /*:85*/
+#line 893 "ctangle.w"
 
 }
 else return'\n';
@@ -889,6 +958,7 @@ else continue;
 }
 loc++;
 if(xisdigit(c)||c=='.')/*73:*/
+#line 962 "ctangle.w"
 {
 boolean hex_flag= false;
 id_first= loc-1;
@@ -922,6 +992,7 @@ return constant;
 }
 
 /*:73*/
+#line 905 "ctangle.w"
 
 else if(c=='\''||c=='"'
 ||((c=='L'||c=='u'||c=='U')&&(*loc=='\''||*loc=='"'))
@@ -971,9 +1042,11 @@ return string;
 }
 
 /*:74*/
+#line 909 "ctangle.w"
 
 else if(isalpha(c)||isxalpha(c)||ishigh(c))
 /*72:*/
+#line 955 "ctangle.w"
 {
 id_first= --loc;
 while(isalpha((eight_bits)*++loc)||isdigit((eight_bits)*loc)
@@ -982,6 +1055,7 @@ id_loc= loc;return identifier;
 }
 
 /*:72*/
+#line 911 "ctangle.w"
 
 else if(c=='@')/*75:*/
 #line 1044 "ctangle.w"
@@ -1005,9 +1079,6 @@ cur_section_name_char= *(loc-1);
 char*k;
 /*79:*/
 #line 1114 "ctangle.w"
-{
-char*k;
-/*79:*/
 
 k= section_text;
 while(true){
@@ -1063,6 +1134,7 @@ else cur_section_name= section_lookup(section_text+1,k,false);
 
 if(cur_section_name_char=='(')
 /*47:*/
+#line 501 "ctangle.w"
 
 {
 for(an_output_file= cur_out_file;
@@ -1088,8 +1160,6 @@ return section_name;
 
 case string:/*81:*/
 #line 1160 "ctangle.w"
-
-case string:/*81:*/
 {
 id_first= loc++;*(limit+1)= '@';*(limit+2)= '>';
 while(*loc!='@'||*(loc+1)!='>')loc++;
@@ -1104,8 +1174,6 @@ return string;
 
 case ord:/*76:*/
 #line 1071 "ctangle.w"
-
-case ord:/*76:*/
 
 id_first= loc;
 if(*loc=='\\'){
@@ -1135,6 +1203,7 @@ default:return c;
 }
 
 /*:75*/
+#line 912 "ctangle.w"
 
 else if(xisspace(c)){
 if(!preprocessing||loc> limit)continue;
@@ -1143,6 +1212,7 @@ else return' ';
 }
 else if(c=='#'&&loc==buffer+1)preprocessing= true;
 mistake:/*71:*/
+#line 933 "ctangle.w"
 
 switch(c){
 case'+':if(*loc=='+')compress(plus_plus);break;
@@ -1166,6 +1236,7 @@ case'!':if(*loc=='=')compress(non_eq);break;
 }
 
 /*:71*/
+#line 919 "ctangle.w"
 
 return c;
 }
@@ -1200,9 +1271,6 @@ app_repl(a_l%0400);}
 while(true)switch(a= get_next()){
 /*86:*/
 #line 1235 "ctangle.w"
-}
-while(true)switch(a= get_next()){
-/*86:*/
 
 case identifier:a= id_lookup(id_first,id_loc,0)-name_dir;
 app_repl((a/0400)+0200);
@@ -1286,7 +1354,6 @@ else err_print("! Double @ should be used in string");
 
 }
 else if(a==constant&&*id_first=='\''&&skip_digit_separators)
-else if(a==constant&&*id_first=='\''&&flags['q'])
 id_first++;
 app_repl(*id_first++);
 }
@@ -1298,9 +1365,6 @@ app_repl(a);break;
 case ord:
 /*89:*/
 #line 1304 "ctangle.w"
-
-case ord:
-/*89:*/
 {
 int c= (eight_bits)*id_first;
 if(c=='\\'){
@@ -1403,9 +1467,6 @@ loc-= 2;next_control= get_next();
 if(next_control==definition){
 /*93:*/
 #line 1411 "ctangle.w"
-
-if(next_control==definition){
-/*93:*/
 {
 while((next_control= get_next())=='\n');
 if(next_control!=identifier){
@@ -1454,8 +1515,6 @@ no_where= print_where= false;
 /*96:*/
 #line 1446 "ctangle.w"
 
-/*96:*/
-
 store_two_bytes((sixteen_bits)(0150000+section_count));
 
 
@@ -1465,9 +1524,6 @@ store_two_bytes((sixteen_bits)(0150000+section_count));
 scan_repl(section_name);
 /*97:*/
 #line 1450 "ctangle.w"
-
-scan_repl(section_name);
-/*97:*/
 
 if(p==name_dir||p==NULL){
 (last_unnamed)->text_link= cur_text-text_info;last_unnamed= cur_text;
@@ -1489,9 +1545,6 @@ cur_text->text_link= section_flag;
 
 /*:95*/
 #line 1393 "ctangle.w"
-
-
-/*:95*/
 
 }
 

--- a/ctangle.c
+++ b/ctangle.c
@@ -1,8 +1,6 @@
 /*1:*/
-#line 66 "ctangle.w"
 
 /*4:*/
-#line 46 "common.h"
 
 #include <ctype.h>  
 #include <stdbool.h>  
@@ -13,7 +11,6 @@
 #include <string.h>  
 
 /*:4*/
-#line 67 "ctangle.w"
 
 #define banner "This is CTANGLE (Version 4.2)" \
 
@@ -143,10 +140,8 @@
 #define skip_digit_separators flags['k'] \
 
 
-#line 68 "ctangle.w"
 
 /*3:*/
-#line 37 "common.h"
 
 typedef bool boolean;
 typedef uint8_t eight_bits;
@@ -155,7 +150,6 @@ extern boolean program;
 extern int phase;
 
 /*:3*//*5:*/
-#line 76 "common.h"
 
 extern char section_text[];
 extern char*section_text_end;
@@ -163,7 +157,6 @@ extern char*id_first;
 extern char*id_loc;
 
 /*:5*//*6:*/
-#line 94 "common.h"
 
 extern char buffer[];
 extern char*buffer_end;
@@ -171,7 +164,6 @@ extern char*loc;
 extern char*limit;
 
 /*:6*//*7:*/
-#line 111 "common.h"
 
 extern int include_depth;
 extern FILE*file[];
@@ -187,7 +179,6 @@ extern boolean changing;
 extern boolean web_file_open;
 
 /*:7*//*9:*/
-#line 131 "common.h"
 
 extern sixteen_bits section_count;
 extern boolean changed_section[];
@@ -195,7 +186,6 @@ extern boolean change_pending;
 extern boolean print_where;
 
 /*:9*//*10:*/
-#line 145 "common.h"
 
 typedef struct name_info{
 char*byte_start;
@@ -220,12 +210,10 @@ extern hash_pointer hash_end;
 extern hash_pointer h;
 
 /*:10*//*12:*/
-#line 189 "common.h"
 
 extern int history;
 
 /*:12*//*14:*/
-#line 205 "common.h"
 
 extern int argc;
 extern char**argv;
@@ -236,7 +224,6 @@ extern char scn_file_name[];
 extern boolean flags[];
 
 /*:14*//*15:*/
-#line 219 "common.h"
 
 extern FILE*C_file;
 extern FILE*tex_file;
@@ -245,10 +232,8 @@ extern FILE*scn_file;
 extern FILE*active_file;
 
 /*:15*/
-#line 69 "ctangle.w"
 
 /*19:*/
-#line 122 "ctangle.w"
 
 typedef struct{
 eight_bits*tok_start;
@@ -257,7 +242,6 @@ sixteen_bits text_link;
 typedef text*text_pointer;
 
 /*:19*//*31:*/
-#line 273 "ctangle.w"
 
 typedef struct{
 eight_bits*end_field;
@@ -269,10 +253,8 @@ sixteen_bits section_field;
 typedef output_state*stack_pointer;
 
 /*:31*/
-#line 70 "ctangle.w"
 
 /*20:*/
-#line 129 "ctangle.w"
 
 static text text_info[max_texts];
 static text_pointer text_info_end= text_info+max_texts-1;
@@ -282,12 +264,10 @@ static eight_bits*tok_mem_end= tok_mem+max_toks-1;
 static eight_bits*tok_ptr;
 
 /*:20*//*26:*/
-#line 199 "ctangle.w"
 
 static text_pointer last_unnamed;
 
 /*:26*//*32:*/
-#line 289 "ctangle.w"
 
 static output_state cur_state;
 
@@ -296,18 +276,15 @@ static stack_pointer stack_end= stack+stack_size;
 static stack_pointer stack_ptr;
 
 /*:32*//*37:*/
-#line 365 "ctangle.w"
 
 static int cur_val;
 
 /*:37*//*42:*/
-#line 456 "ctangle.w"
 
 static eight_bits out_state;
 static boolean protect;
 
 /*:42*//*45:*/
-#line 487 "ctangle.w"
 
 static name_pointer output_files[max_files];
 static name_pointer*cur_out_file,*end_output_files,*an_output_file;
@@ -315,27 +292,22 @@ static char cur_section_name_char;
 static char output_file_name[longest_name+1];
 
 /*:45*//*52:*/
-#line 586 "ctangle.w"
 
 static boolean output_defs_seen= false;
 
 /*:52*//*57:*/
-#line 698 "ctangle.w"
 
 static char translit[128][translit_length];
 
 /*:57*//*62:*/
-#line 777 "ctangle.w"
 
 static eight_bits ccode[256];
 
 /*:62*//*66:*/
-#line 837 "ctangle.w"
 
 static boolean comment_continues= false;
 
 /*:66*//*68:*/
-#line 874 "ctangle.w"
 
 static name_pointer cur_section_name;
 static boolean no_where;
@@ -347,17 +319,14 @@ static text_pointer cur_text;
 static eight_bits next_control;
 
 /*:82*/
-#line 71 "ctangle.w"
 
 /*8:*/
-#line 125 "common.h"
 
 extern boolean get_line(void);
 extern void check_complete(void);
 extern void reset_input(void);
 
 /*:8*//*11:*/
-#line 168 "common.h"
 
 extern boolean names_match(name_pointer,const char*,size_t,eight_bits);
 extern name_pointer id_lookup(const char*,const char*,char);
@@ -370,7 +339,6 @@ extern void print_section_name(name_pointer);
 extern void sprint_section_name(char*,name_pointer);
 
 /*:11*//*13:*/
-#line 192 "common.h"
 
 extern int wrap_up(void);
 extern void err_print(const char*);
@@ -378,47 +346,38 @@ extern void fatal(const char*,const char*);
 extern void overflow(const char*);
 
 /*:13*//*16:*/
-#line 227 "common.h"
 
 extern void common_init(void);
 extern void print_stats(void);
 
 /*:16*//*30:*/
-#line 245 "ctangle.w"
 static void store_two_bytes(sixteen_bits);
 
 /*:30*//*35:*/
-#line 328 "ctangle.w"
 
 static void push_level(name_pointer);
 static void pop_level(boolean);
 
 /*:35*//*39:*/
-#line 401 "ctangle.w"
 static void get_output(void);
 
 /*:39*//*44:*/
-#line 477 "ctangle.w"
 static void flush_buffer(void);
 
 /*:44*//*49:*/
-#line 553 "ctangle.w"
 static void phase_two(void);
 
 /*:49*//*53:*/
-#line 589 "ctangle.w"
 
 static void output_defs(void);
 static void out_char(eight_bits);
 
 /*:53*//*65:*/
-#line 817 "ctangle.w"
 
 static eight_bits skip_ahead(void);
 static boolean skip_comment(boolean);
 
 /*:65*//*70:*/
-#line 924 "ctangle.w"
 static eight_bits get_next(void);
 
 /*:70*//*84:*/
@@ -435,14 +394,21 @@ static void phase_one(void);
 
 /*:99*//*101:*/
 #line 1511 "ctangle.w"
+static void scan_repl(eight_bits);
+
+/*:84*//*91:*/
+static void scan_section(void);
+
+/*:91*//*99:*/
+static void phase_one(void);
+
+/*:99*//*101:*/
 static void skip_limbo(void);
 
 /*:101*/
-#line 72 "ctangle.w"
 
 
 /*:1*//*2:*/
-#line 81 "ctangle.w"
 
 int main(
 int ac,
@@ -451,28 +417,23 @@ char**av)
 argc= ac;argv= av;
 program= ctangle;
 /*21:*/
-#line 137 "ctangle.w"
 
 text_info->tok_start= tok_ptr= tok_mem;
 text_ptr= text_info+1;text_ptr->tok_start= tok_mem;
 
 
 /*:21*//*23:*/
-#line 147 "ctangle.w"
 
 init_node(name_dir);
 
 /*:23*//*27:*/
-#line 202 "ctangle.w"
 last_unnamed= text_info;text_info->text_link= macro;
 
 /*:27*//*46:*/
-#line 497 "ctangle.w"
 
 cur_out_file= end_output_files= output_files+max_files;
 
 /*:46*//*58:*/
-#line 701 "ctangle.w"
 
 {
 int i;
@@ -480,7 +441,6 @@ for(i= 0;i<128;i++)sprintf(translit[i],"X%02X",(unsigned int)(128+i));
 }
 
 /*:58*//*63:*/
-#line 780 "ctangle.w"
 {
 int c;
 for(c= 0;c<256;c++)ccode[c]= ignore;
@@ -504,7 +464,6 @@ ccode['\'']= ord;
 section_text[0]= ' ';
 
 /*:78*/
-#line 88 "ctangle.w"
 
 common_init();
 if(show_banner)puts(banner);
@@ -514,7 +473,6 @@ return wrap_up();
 }
 
 /*:2*//*24:*/
-#line 153 "ctangle.w"
 
 boolean names_match(
 name_pointer p,
@@ -527,7 +485,6 @@ return!strncmp(first,p->byte_start,l);
 }
 
 /*:24*//*25:*/
-#line 169 "ctangle.w"
 
 void
 init_node(
@@ -539,7 +496,6 @@ void
 init_p(name_pointer p,eight_bits t){(void)p;(void)t;}
 
 /*:25*//*29:*/
-#line 235 "ctangle.w"
 
 static void
 store_two_bytes(
@@ -551,7 +507,6 @@ if(tok_ptr+2> tok_mem_end)overflow("token");
 }
 
 /*:29*//*34:*/
-#line 313 "ctangle.w"
 
 static void
 push_level(
@@ -568,7 +523,6 @@ cur_section= 0;
 }
 
 /*:34*//*36:*/
-#line 336 "ctangle.w"
 
 static void
 pop_level(
@@ -584,7 +538,6 @@ if(stack_ptr> stack)cur_state= *stack_ptr;
 }
 
 /*:36*//*38:*/
-#line 372 "ctangle.w"
 
 static void
 get_output(void)
@@ -607,7 +560,6 @@ switch(a/024000){
 case 0:cur_val= a;out_char(identifier);break;
 case 1:if(a==output_defs_flag)output_defs();
 else/*40:*/
-#line 406 "ctangle.w"
 
 {
 a-= 024000;
@@ -621,7 +573,6 @@ goto restart;
 }
 
 /*:40*/
-#line 393 "ctangle.w"
 
 break;
 default:cur_val= a-050000;if(cur_val> 0)cur_section= cur_val;
@@ -631,7 +582,6 @@ out_char(section_number);
 }
 
 /*:38*//*43:*/
-#line 464 "ctangle.w"
 
 static void
 flush_buffer(void)
@@ -646,29 +596,24 @@ cur_line++;
 }
 
 /*:43*//*48:*/
-#line 518 "ctangle.w"
 
 static void
 phase_two(void){
 web_file_open= false;
 cur_line= 1;
 /*33:*/
-#line 302 "ctangle.w"
 
 stack_ptr= stack+1;cur_name= name_dir;cur_repl= text_info->text_link+text_info;
 cur_byte= cur_repl->tok_start;cur_end= (cur_repl+1)->tok_start;cur_section= 0;
 
 /*:33*/
-#line 523 "ctangle.w"
 
 /*51:*/
-#line 582 "ctangle.w"
 
 if(!output_defs_seen)
 output_defs();
 
 /*:51*/
-#line 524 "ctangle.w"
 
 if(text_info->text_link==macro&&cur_out_file==end_output_files){
 fputs("\n! No program text was specified.",stdout);mark_harmless;
@@ -691,7 +636,6 @@ if(text_info->text_link==macro)goto writeloop;
 while(stack_ptr> stack)get_output();
 flush_buffer();
 writeloop:/*50:*/
-#line 559 "ctangle.w"
 
 for(an_output_file= end_output_files;an_output_file> cur_out_file;){
 an_output_file--;
@@ -712,7 +656,6 @@ flush_buffer();
 }
 
 /*:50*/
-#line 545 "ctangle.w"
 
 if(show_happiness){
 if(show_progress)new_line;
@@ -722,7 +665,6 @@ fputs("Done.",stdout);
 }
 
 /*:48*//*54:*/
-#line 596 "ctangle.w"
 
 static void
 output_defs(void)
@@ -762,7 +704,6 @@ pop_level(false);
 }
 
 /*:54*//*55:*/
-#line 639 "ctangle.w"
 
 static void
 out_char(
@@ -775,7 +716,6 @@ case'\n':if(protect&&out_state!=verbatim)C_putc(' ');
 if(protect||out_state==verbatim)C_putc('\\');
 flush_buffer();if(out_state!=verbatim)out_state= normal;break;
 /*59:*/
-#line 707 "ctangle.w"
 
 case identifier:
 if(out_state==num_or_id)C_putc(' ');
@@ -790,10 +730,8 @@ j++;
 out_state= num_or_id;break;
 
 /*:59*/
-#line 650 "ctangle.w"
 
 /*60:*/
-#line 720 "ctangle.w"
 
 case section_number:
 if(cur_val> 0)C_printf("/*%d:*/",cur_val);
@@ -820,10 +758,8 @@ C_putc('"');C_putc('\n');
 break;
 
 /*:60*/
-#line 651 "ctangle.w"
 
 /*56:*/
-#line 669 "ctangle.w"
 
 case plus_plus:C_putc('+');C_putc('+');out_state= normal;break;
 case minus_minus:C_putc('-');C_putc('-');out_state= normal;break;
@@ -844,7 +780,6 @@ case minus_gt_ast:C_putc('-');C_putc('>');C_putc('*');out_state= normal;
 break;
 
 /*:56*/
-#line 652 "ctangle.w"
 
 case'=':case'>':C_putc(cur_char);C_putc(' ');
 out_state= normal;break;
@@ -863,7 +798,6 @@ default:C_putc(cur_char);out_state= normal;break;
 }
 
 /*:55*//*64:*/
-#line 801 "ctangle.w"
 
 static eight_bits
 skip_ahead(void)
@@ -881,7 +815,6 @@ if(c!=ignore||*(loc-1)=='>')return c;
 }
 
 /*:64*//*67:*/
-#line 840 "ctangle.w"
 
 static boolean skip_comment(
 boolean is_long_comment)
@@ -915,7 +848,6 @@ else loc++;
 }
 
 /*:67*//*69:*/
-#line 881 "ctangle.w"
 
 static eight_bits
 get_next(void)
@@ -944,7 +876,6 @@ id_loc= id_first+strlen(id_first);
 app_repl(a_l%0400);}
 
 /*:85*/
-#line 893 "ctangle.w"
 
 }
 else return'\n';
@@ -958,7 +889,6 @@ else continue;
 }
 loc++;
 if(xisdigit(c)||c=='.')/*73:*/
-#line 962 "ctangle.w"
 {
 boolean hex_flag= false;
 id_first= loc-1;
@@ -992,7 +922,6 @@ return constant;
 }
 
 /*:73*/
-#line 905 "ctangle.w"
 
 else if(c=='\''||c=='"'
 ||((c=='L'||c=='u'||c=='U')&&(*loc=='\''||*loc=='"'))
@@ -1042,11 +971,9 @@ return string;
 }
 
 /*:74*/
-#line 909 "ctangle.w"
 
 else if(isalpha(c)||isxalpha(c)||ishigh(c))
 /*72:*/
-#line 955 "ctangle.w"
 {
 id_first= --loc;
 while(isalpha((eight_bits)*++loc)||isdigit((eight_bits)*loc)
@@ -1055,7 +982,6 @@ id_loc= loc;return identifier;
 }
 
 /*:72*/
-#line 911 "ctangle.w"
 
 else if(c=='@')/*75:*/
 #line 1044 "ctangle.w"
@@ -1079,6 +1005,9 @@ cur_section_name_char= *(loc-1);
 char*k;
 /*79:*/
 #line 1114 "ctangle.w"
+{
+char*k;
+/*79:*/
 
 k= section_text;
 while(true){
@@ -1134,7 +1063,6 @@ else cur_section_name= section_lookup(section_text+1,k,false);
 
 if(cur_section_name_char=='(')
 /*47:*/
-#line 501 "ctangle.w"
 
 {
 for(an_output_file= cur_out_file;
@@ -1160,6 +1088,8 @@ return section_name;
 
 case string:/*81:*/
 #line 1160 "ctangle.w"
+
+case string:/*81:*/
 {
 id_first= loc++;*(limit+1)= '@';*(limit+2)= '>';
 while(*loc!='@'||*(loc+1)!='>')loc++;
@@ -1174,6 +1104,8 @@ return string;
 
 case ord:/*76:*/
 #line 1071 "ctangle.w"
+
+case ord:/*76:*/
 
 id_first= loc;
 if(*loc=='\\'){
@@ -1203,7 +1135,6 @@ default:return c;
 }
 
 /*:75*/
-#line 912 "ctangle.w"
 
 else if(xisspace(c)){
 if(!preprocessing||loc> limit)continue;
@@ -1212,7 +1143,6 @@ else return' ';
 }
 else if(c=='#'&&loc==buffer+1)preprocessing= true;
 mistake:/*71:*/
-#line 933 "ctangle.w"
 
 switch(c){
 case'+':if(*loc=='+')compress(plus_plus);break;
@@ -1236,7 +1166,6 @@ case'!':if(*loc=='=')compress(non_eq);break;
 }
 
 /*:71*/
-#line 919 "ctangle.w"
 
 return c;
 }
@@ -1271,6 +1200,9 @@ app_repl(a_l%0400);}
 while(true)switch(a= get_next()){
 /*86:*/
 #line 1235 "ctangle.w"
+}
+while(true)switch(a= get_next()){
+/*86:*/
 
 case identifier:a= id_lookup(id_first,id_loc,0)-name_dir;
 app_repl((a/0400)+0200);
@@ -1354,6 +1286,7 @@ else err_print("! Double @ should be used in string");
 
 }
 else if(a==constant&&*id_first=='\''&&skip_digit_separators)
+else if(a==constant&&*id_first=='\''&&flags['q'])
 id_first++;
 app_repl(*id_first++);
 }
@@ -1365,6 +1298,9 @@ app_repl(a);break;
 case ord:
 /*89:*/
 #line 1304 "ctangle.w"
+
+case ord:
+/*89:*/
 {
 int c= (eight_bits)*id_first;
 if(c=='\\'){
@@ -1467,6 +1403,9 @@ loc-= 2;next_control= get_next();
 if(next_control==definition){
 /*93:*/
 #line 1411 "ctangle.w"
+
+if(next_control==definition){
+/*93:*/
 {
 while((next_control= get_next())=='\n');
 if(next_control!=identifier){
@@ -1515,6 +1454,8 @@ no_where= print_where= false;
 /*96:*/
 #line 1446 "ctangle.w"
 
+/*96:*/
+
 store_two_bytes((sixteen_bits)(0150000+section_count));
 
 
@@ -1524,6 +1465,9 @@ store_two_bytes((sixteen_bits)(0150000+section_count));
 scan_repl(section_name);
 /*97:*/
 #line 1450 "ctangle.w"
+
+scan_repl(section_name);
+/*97:*/
 
 if(p==name_dir||p==NULL){
 (last_unnamed)->text_link= cur_text-text_info;last_unnamed= cur_text;
@@ -1545,6 +1489,9 @@ cur_text->text_link= section_flag;
 
 /*:95*/
 #line 1393 "ctangle.w"
+
+
+/*:95*/
 
 }
 

--- a/ctangle.c
+++ b/ctangle.c
@@ -1,8 +1,8 @@
 /*1:*/
-#line 66 "./ctangle.w"
+#line 66 "ctangle.w"
 
 /*4:*/
-#line 46 "./common.h"
+#line 46 "common.h"
 
 #include <ctype.h>  
 #include <stdbool.h>  
@@ -13,7 +13,7 @@
 #include <string.h>  
 
 /*:4*/
-#line 67 "./ctangle.w"
+#line 67 "ctangle.w"
 
 #define banner "This is CTANGLE (Version 4.2)" \
 
@@ -140,11 +140,13 @@
 
 #define app_repl(c) {if(tok_ptr==tok_mem_end) overflow("token") ;*tok_ptr++= c;} \
 
+#define skip_digit_separators flags['k'] \
 
-#line 68 "./ctangle.w"
+
+#line 68 "ctangle.w"
 
 /*3:*/
-#line 37 "./common.h"
+#line 37 "common.h"
 
 typedef bool boolean;
 typedef uint8_t eight_bits;
@@ -153,7 +155,7 @@ extern boolean program;
 extern int phase;
 
 /*:3*//*5:*/
-#line 76 "./common.h"
+#line 76 "common.h"
 
 extern char section_text[];
 extern char*section_text_end;
@@ -161,7 +163,7 @@ extern char*id_first;
 extern char*id_loc;
 
 /*:5*//*6:*/
-#line 94 "./common.h"
+#line 94 "common.h"
 
 extern char buffer[];
 extern char*buffer_end;
@@ -169,7 +171,7 @@ extern char*loc;
 extern char*limit;
 
 /*:6*//*7:*/
-#line 111 "./common.h"
+#line 111 "common.h"
 
 extern int include_depth;
 extern FILE*file[];
@@ -185,7 +187,7 @@ extern boolean changing;
 extern boolean web_file_open;
 
 /*:7*//*9:*/
-#line 131 "./common.h"
+#line 131 "common.h"
 
 extern sixteen_bits section_count;
 extern boolean changed_section[];
@@ -193,7 +195,7 @@ extern boolean change_pending;
 extern boolean print_where;
 
 /*:9*//*10:*/
-#line 145 "./common.h"
+#line 145 "common.h"
 
 typedef struct name_info{
 char*byte_start;
@@ -218,12 +220,12 @@ extern hash_pointer hash_end;
 extern hash_pointer h;
 
 /*:10*//*12:*/
-#line 189 "./common.h"
+#line 189 "common.h"
 
 extern int history;
 
 /*:12*//*14:*/
-#line 205 "./common.h"
+#line 205 "common.h"
 
 extern int argc;
 extern char**argv;
@@ -234,7 +236,7 @@ extern char scn_file_name[];
 extern boolean flags[];
 
 /*:14*//*15:*/
-#line 219 "./common.h"
+#line 219 "common.h"
 
 extern FILE*C_file;
 extern FILE*tex_file;
@@ -243,10 +245,10 @@ extern FILE*scn_file;
 extern FILE*active_file;
 
 /*:15*/
-#line 69 "./ctangle.w"
+#line 69 "ctangle.w"
 
 /*19:*/
-#line 122 "./ctangle.w"
+#line 122 "ctangle.w"
 
 typedef struct{
 eight_bits*tok_start;
@@ -255,7 +257,7 @@ sixteen_bits text_link;
 typedef text*text_pointer;
 
 /*:19*//*31:*/
-#line 273 "./ctangle.w"
+#line 273 "ctangle.w"
 
 typedef struct{
 eight_bits*end_field;
@@ -267,10 +269,10 @@ sixteen_bits section_field;
 typedef output_state*stack_pointer;
 
 /*:31*/
-#line 70 "./ctangle.w"
+#line 70 "ctangle.w"
 
 /*20:*/
-#line 129 "./ctangle.w"
+#line 129 "ctangle.w"
 
 static text text_info[max_texts];
 static text_pointer text_info_end= text_info+max_texts-1;
@@ -280,12 +282,12 @@ static eight_bits*tok_mem_end= tok_mem+max_toks-1;
 static eight_bits*tok_ptr;
 
 /*:20*//*26:*/
-#line 199 "./ctangle.w"
+#line 199 "ctangle.w"
 
 static text_pointer last_unnamed;
 
 /*:26*//*32:*/
-#line 289 "./ctangle.w"
+#line 289 "ctangle.w"
 
 static output_state cur_state;
 
@@ -294,18 +296,18 @@ static stack_pointer stack_end= stack+stack_size;
 static stack_pointer stack_ptr;
 
 /*:32*//*37:*/
-#line 365 "./ctangle.w"
+#line 365 "ctangle.w"
 
 static int cur_val;
 
 /*:37*//*42:*/
-#line 456 "./ctangle.w"
+#line 456 "ctangle.w"
 
 static eight_bits out_state;
 static boolean protect;
 
 /*:42*//*45:*/
-#line 487 "./ctangle.w"
+#line 487 "ctangle.w"
 
 static name_pointer output_files[max_files];
 static name_pointer*cur_out_file,*end_output_files,*an_output_file;
@@ -313,49 +315,49 @@ static char cur_section_name_char;
 static char output_file_name[longest_name+1];
 
 /*:45*//*52:*/
-#line 586 "./ctangle.w"
+#line 586 "ctangle.w"
 
 static boolean output_defs_seen= false;
 
 /*:52*//*57:*/
-#line 698 "./ctangle.w"
+#line 698 "ctangle.w"
 
 static char translit[128][translit_length];
 
 /*:57*//*62:*/
-#line 777 "./ctangle.w"
+#line 777 "ctangle.w"
 
 static eight_bits ccode[256];
 
 /*:62*//*66:*/
-#line 837 "./ctangle.w"
+#line 837 "ctangle.w"
 
 static boolean comment_continues= false;
 
 /*:66*//*68:*/
-#line 874 "./ctangle.w"
+#line 874 "ctangle.w"
 
 static name_pointer cur_section_name;
 static boolean no_where;
 
 /*:68*//*82:*/
-#line 1190 "./ctangle.w"
+#line 1190 "ctangle.w"
 
 static text_pointer cur_text;
 static eight_bits next_control;
 
 /*:82*/
-#line 71 "./ctangle.w"
+#line 71 "ctangle.w"
 
 /*8:*/
-#line 125 "./common.h"
+#line 125 "common.h"
 
 extern boolean get_line(void);
 extern void check_complete(void);
 extern void reset_input(void);
 
 /*:8*//*11:*/
-#line 168 "./common.h"
+#line 168 "common.h"
 
 extern boolean names_match(name_pointer,const char*,size_t,eight_bits);
 extern name_pointer id_lookup(const char*,const char*,char);
@@ -368,7 +370,7 @@ extern void print_section_name(name_pointer);
 extern void sprint_section_name(char*,name_pointer);
 
 /*:11*//*13:*/
-#line 192 "./common.h"
+#line 192 "common.h"
 
 extern int wrap_up(void);
 extern void err_print(const char*);
@@ -376,71 +378,71 @@ extern void fatal(const char*,const char*);
 extern void overflow(const char*);
 
 /*:13*//*16:*/
-#line 227 "./common.h"
+#line 227 "common.h"
 
 extern void common_init(void);
 extern void print_stats(void);
 
 /*:16*//*30:*/
-#line 245 "./ctangle.w"
+#line 245 "ctangle.w"
 static void store_two_bytes(sixteen_bits);
 
 /*:30*//*35:*/
-#line 328 "./ctangle.w"
+#line 328 "ctangle.w"
 
 static void push_level(name_pointer);
 static void pop_level(boolean);
 
 /*:35*//*39:*/
-#line 401 "./ctangle.w"
+#line 401 "ctangle.w"
 static void get_output(void);
 
 /*:39*//*44:*/
-#line 477 "./ctangle.w"
+#line 477 "ctangle.w"
 static void flush_buffer(void);
 
 /*:44*//*49:*/
-#line 553 "./ctangle.w"
+#line 553 "ctangle.w"
 static void phase_two(void);
 
 /*:49*//*53:*/
-#line 589 "./ctangle.w"
+#line 589 "ctangle.w"
 
 static void output_defs(void);
 static void out_char(eight_bits);
 
 /*:53*//*65:*/
-#line 817 "./ctangle.w"
+#line 817 "ctangle.w"
 
 static eight_bits skip_ahead(void);
 static boolean skip_comment(boolean);
 
 /*:65*//*70:*/
-#line 924 "./ctangle.w"
+#line 924 "ctangle.w"
 static eight_bits get_next(void);
 
 /*:70*//*84:*/
-#line 1216 "./ctangle.w"
+#line 1216 "ctangle.w"
 static void scan_repl(eight_bits);
 
 /*:84*//*91:*/
-#line 1389 "./ctangle.w"
+#line 1396 "ctangle.w"
 static void scan_section(void);
 
 /*:91*//*99:*/
-#line 1470 "./ctangle.w"
+#line 1477 "ctangle.w"
 static void phase_one(void);
 
 /*:99*//*101:*/
-#line 1504 "./ctangle.w"
+#line 1511 "ctangle.w"
 static void skip_limbo(void);
 
 /*:101*/
-#line 72 "./ctangle.w"
+#line 72 "ctangle.w"
 
 
 /*:1*//*2:*/
-#line 81 "./ctangle.w"
+#line 81 "ctangle.w"
 
 int main(
 int ac,
@@ -449,28 +451,28 @@ char**av)
 argc= ac;argv= av;
 program= ctangle;
 /*21:*/
-#line 137 "./ctangle.w"
+#line 137 "ctangle.w"
 
 text_info->tok_start= tok_ptr= tok_mem;
 text_ptr= text_info+1;text_ptr->tok_start= tok_mem;
 
 
 /*:21*//*23:*/
-#line 147 "./ctangle.w"
+#line 147 "ctangle.w"
 
 init_node(name_dir);
 
 /*:23*//*27:*/
-#line 202 "./ctangle.w"
+#line 202 "ctangle.w"
 last_unnamed= text_info;text_info->text_link= macro;
 
 /*:27*//*46:*/
-#line 497 "./ctangle.w"
+#line 497 "ctangle.w"
 
 cur_out_file= end_output_files= output_files+max_files;
 
 /*:46*//*58:*/
-#line 701 "./ctangle.w"
+#line 701 "ctangle.w"
 
 {
 int i;
@@ -478,7 +480,7 @@ for(i= 0;i<128;i++)sprintf(translit[i],"X%02X",(unsigned int)(128+i));
 }
 
 /*:58*//*63:*/
-#line 780 "./ctangle.w"
+#line 780 "ctangle.w"
 {
 int c;
 for(c= 0;c<256;c++)ccode[c]= ignore;
@@ -498,11 +500,11 @@ ccode['\'']= ord;
 }
 
 /*:63*//*78:*/
-#line 1112 "./ctangle.w"
+#line 1112 "ctangle.w"
 section_text[0]= ' ';
 
 /*:78*/
-#line 88 "./ctangle.w"
+#line 88 "ctangle.w"
 
 common_init();
 if(show_banner)puts(banner);
@@ -512,7 +514,7 @@ return wrap_up();
 }
 
 /*:2*//*24:*/
-#line 153 "./ctangle.w"
+#line 153 "ctangle.w"
 
 boolean names_match(
 name_pointer p,
@@ -525,7 +527,7 @@ return!strncmp(first,p->byte_start,l);
 }
 
 /*:24*//*25:*/
-#line 169 "./ctangle.w"
+#line 169 "ctangle.w"
 
 void
 init_node(
@@ -537,7 +539,7 @@ void
 init_p(name_pointer p,eight_bits t){(void)p;(void)t;}
 
 /*:25*//*29:*/
-#line 235 "./ctangle.w"
+#line 235 "ctangle.w"
 
 static void
 store_two_bytes(
@@ -549,7 +551,7 @@ if(tok_ptr+2> tok_mem_end)overflow("token");
 }
 
 /*:29*//*34:*/
-#line 313 "./ctangle.w"
+#line 313 "ctangle.w"
 
 static void
 push_level(
@@ -566,7 +568,7 @@ cur_section= 0;
 }
 
 /*:34*//*36:*/
-#line 336 "./ctangle.w"
+#line 336 "ctangle.w"
 
 static void
 pop_level(
@@ -582,7 +584,7 @@ if(stack_ptr> stack)cur_state= *stack_ptr;
 }
 
 /*:36*//*38:*/
-#line 372 "./ctangle.w"
+#line 372 "ctangle.w"
 
 static void
 get_output(void)
@@ -605,7 +607,7 @@ switch(a/024000){
 case 0:cur_val= a;out_char(identifier);break;
 case 1:if(a==output_defs_flag)output_defs();
 else/*40:*/
-#line 406 "./ctangle.w"
+#line 406 "ctangle.w"
 
 {
 a-= 024000;
@@ -619,7 +621,7 @@ goto restart;
 }
 
 /*:40*/
-#line 393 "./ctangle.w"
+#line 393 "ctangle.w"
 
 break;
 default:cur_val= a-050000;if(cur_val> 0)cur_section= cur_val;
@@ -629,7 +631,7 @@ out_char(section_number);
 }
 
 /*:38*//*43:*/
-#line 464 "./ctangle.w"
+#line 464 "ctangle.w"
 
 static void
 flush_buffer(void)
@@ -644,29 +646,29 @@ cur_line++;
 }
 
 /*:43*//*48:*/
-#line 518 "./ctangle.w"
+#line 518 "ctangle.w"
 
 static void
 phase_two(void){
 web_file_open= false;
 cur_line= 1;
 /*33:*/
-#line 302 "./ctangle.w"
+#line 302 "ctangle.w"
 
 stack_ptr= stack+1;cur_name= name_dir;cur_repl= text_info->text_link+text_info;
 cur_byte= cur_repl->tok_start;cur_end= (cur_repl+1)->tok_start;cur_section= 0;
 
 /*:33*/
-#line 523 "./ctangle.w"
+#line 523 "ctangle.w"
 
 /*51:*/
-#line 582 "./ctangle.w"
+#line 582 "ctangle.w"
 
 if(!output_defs_seen)
 output_defs();
 
 /*:51*/
-#line 524 "./ctangle.w"
+#line 524 "ctangle.w"
 
 if(text_info->text_link==macro&&cur_out_file==end_output_files){
 fputs("\n! No program text was specified.",stdout);mark_harmless;
@@ -689,7 +691,7 @@ if(text_info->text_link==macro)goto writeloop;
 while(stack_ptr> stack)get_output();
 flush_buffer();
 writeloop:/*50:*/
-#line 559 "./ctangle.w"
+#line 559 "ctangle.w"
 
 for(an_output_file= end_output_files;an_output_file> cur_out_file;){
 an_output_file--;
@@ -710,7 +712,7 @@ flush_buffer();
 }
 
 /*:50*/
-#line 545 "./ctangle.w"
+#line 545 "ctangle.w"
 
 if(show_happiness){
 if(show_progress)new_line;
@@ -720,7 +722,7 @@ fputs("Done.",stdout);
 }
 
 /*:48*//*54:*/
-#line 596 "./ctangle.w"
+#line 596 "ctangle.w"
 
 static void
 output_defs(void)
@@ -760,7 +762,7 @@ pop_level(false);
 }
 
 /*:54*//*55:*/
-#line 639 "./ctangle.w"
+#line 639 "ctangle.w"
 
 static void
 out_char(
@@ -773,7 +775,7 @@ case'\n':if(protect&&out_state!=verbatim)C_putc(' ');
 if(protect||out_state==verbatim)C_putc('\\');
 flush_buffer();if(out_state!=verbatim)out_state= normal;break;
 /*59:*/
-#line 707 "./ctangle.w"
+#line 707 "ctangle.w"
 
 case identifier:
 if(out_state==num_or_id)C_putc(' ');
@@ -788,10 +790,10 @@ j++;
 out_state= num_or_id;break;
 
 /*:59*/
-#line 650 "./ctangle.w"
+#line 650 "ctangle.w"
 
 /*60:*/
-#line 720 "./ctangle.w"
+#line 720 "ctangle.w"
 
 case section_number:
 if(cur_val> 0)C_printf("/*%d:*/",cur_val);
@@ -818,10 +820,10 @@ C_putc('"');C_putc('\n');
 break;
 
 /*:60*/
-#line 651 "./ctangle.w"
+#line 651 "ctangle.w"
 
 /*56:*/
-#line 669 "./ctangle.w"
+#line 669 "ctangle.w"
 
 case plus_plus:C_putc('+');C_putc('+');out_state= normal;break;
 case minus_minus:C_putc('-');C_putc('-');out_state= normal;break;
@@ -842,7 +844,7 @@ case minus_gt_ast:C_putc('-');C_putc('>');C_putc('*');out_state= normal;
 break;
 
 /*:56*/
-#line 652 "./ctangle.w"
+#line 652 "ctangle.w"
 
 case'=':case'>':C_putc(cur_char);C_putc(' ');
 out_state= normal;break;
@@ -861,7 +863,7 @@ default:C_putc(cur_char);out_state= normal;break;
 }
 
 /*:55*//*64:*/
-#line 801 "./ctangle.w"
+#line 801 "ctangle.w"
 
 static eight_bits
 skip_ahead(void)
@@ -879,7 +881,7 @@ if(c!=ignore||*(loc-1)=='>')return c;
 }
 
 /*:64*//*67:*/
-#line 840 "./ctangle.w"
+#line 840 "ctangle.w"
 
 static boolean skip_comment(
 boolean is_long_comment)
@@ -913,7 +915,7 @@ else loc++;
 }
 
 /*:67*//*69:*/
-#line 881 "./ctangle.w"
+#line 881 "ctangle.w"
 
 static eight_bits
 get_next(void)
@@ -927,7 +929,7 @@ if(get_line()==false)return new_section;
 else if(print_where&&!no_where){
 print_where= false;
 /*85:*/
-#line 1222 "./ctangle.w"
+#line 1222 "ctangle.w"
 
 store_two_bytes(0150000);
 if(changing&&include_depth==change_depth){
@@ -942,7 +944,7 @@ id_loc= id_first+strlen(id_first);
 app_repl(a_l%0400);}
 
 /*:85*/
-#line 893 "./ctangle.w"
+#line 893 "ctangle.w"
 
 }
 else return'\n';
@@ -956,7 +958,7 @@ else continue;
 }
 loc++;
 if(xisdigit(c)||c=='.')/*73:*/
-#line 962 "./ctangle.w"
+#line 962 "ctangle.w"
 {
 boolean hex_flag= false;
 id_first= loc-1;
@@ -990,13 +992,13 @@ return constant;
 }
 
 /*:73*/
-#line 905 "./ctangle.w"
+#line 905 "ctangle.w"
 
 else if(c=='\''||c=='"'
 ||((c=='L'||c=='u'||c=='U')&&(*loc=='\''||*loc=='"'))
 ||((c=='u'&&*loc=='8')&&(*(loc+1)=='\''||*(loc+1)=='"')))
 /*74:*/
-#line 999 "./ctangle.w"
+#line 999 "ctangle.w"
 {
 char delim= c;
 id_first= section_text+1;
@@ -1040,11 +1042,11 @@ return string;
 }
 
 /*:74*/
-#line 909 "./ctangle.w"
+#line 909 "ctangle.w"
 
 else if(isalpha(c)||isxalpha(c)||ishigh(c))
 /*72:*/
-#line 955 "./ctangle.w"
+#line 955 "ctangle.w"
 {
 id_first= --loc;
 while(isalpha((eight_bits)*++loc)||isdigit((eight_bits)*loc)
@@ -1053,10 +1055,10 @@ id_loc= loc;return identifier;
 }
 
 /*:72*/
-#line 911 "./ctangle.w"
+#line 911 "ctangle.w"
 
 else if(c=='@')/*75:*/
-#line 1044 "./ctangle.w"
+#line 1044 "ctangle.w"
 {
 c= ccode[(eight_bits)*loc++];
 switch(c){
@@ -1072,11 +1074,11 @@ continue;
 case section_name:
 cur_section_name_char= *(loc-1);
 /*77:*/
-#line 1092 "./ctangle.w"
+#line 1092 "ctangle.w"
 {
 char*k;
 /*79:*/
-#line 1114 "./ctangle.w"
+#line 1114 "ctangle.w"
 
 k= section_text;
 while(true){
@@ -1087,7 +1089,7 @@ loc= buffer+1;break;
 }
 c= *loc;
 /*80:*/
-#line 1138 "./ctangle.w"
+#line 1138 "ctangle.w"
 
 if(c=='@'){
 c= *(loc+1);
@@ -1106,7 +1108,7 @@ err_print("! Nesting of section names not allowed");break;
 }
 
 /*:80*/
-#line 1123 "./ctangle.w"
+#line 1123 "ctangle.w"
 
 loc++;if(k<section_text_end)k++;
 if(xisspace(c)){
@@ -1123,7 +1125,7 @@ printf("...");mark_harmless;
 if(*k==' '&&k> section_text)k--;
 
 /*:79*/
-#line 1094 "./ctangle.w"
+#line 1094 "ctangle.w"
 
 if(k-section_text> 3&&strncmp(k-2,"...",3)==0)
 cur_section_name= section_lookup(section_text+1,k-3,true);
@@ -1132,7 +1134,7 @@ else cur_section_name= section_lookup(section_text+1,k,false);
 
 if(cur_section_name_char=='(')
 /*47:*/
-#line 501 "./ctangle.w"
+#line 501 "ctangle.w"
 
 {
 for(an_output_file= cur_out_file;
@@ -1148,16 +1150,16 @@ overflow("output files");
 }
 
 /*:47*/
-#line 1102 "./ctangle.w"
+#line 1102 "ctangle.w"
 
 return section_name;
 }
 
 /*:77*/
-#line 1058 "./ctangle.w"
+#line 1058 "ctangle.w"
 
 case string:/*81:*/
-#line 1160 "./ctangle.w"
+#line 1160 "ctangle.w"
 {
 id_first= loc++;*(limit+1)= '@';*(limit+2)= '>';
 while(*loc!='@'||*(loc+1)!='>')loc++;
@@ -1168,10 +1170,10 @@ return string;
 }
 
 /*:81*/
-#line 1059 "./ctangle.w"
+#line 1059 "ctangle.w"
 
 case ord:/*76:*/
-#line 1071 "./ctangle.w"
+#line 1071 "ctangle.w"
 
 id_first= loc;
 if(*loc=='\\'){
@@ -1194,14 +1196,14 @@ loc++;
 return ord;
 
 /*:76*/
-#line 1060 "./ctangle.w"
+#line 1060 "ctangle.w"
 
 default:return c;
 }
 }
 
 /*:75*/
-#line 912 "./ctangle.w"
+#line 912 "ctangle.w"
 
 else if(xisspace(c)){
 if(!preprocessing||loc> limit)continue;
@@ -1210,7 +1212,7 @@ else return' ';
 }
 else if(c=='#'&&loc==buffer+1)preprocessing= true;
 mistake:/*71:*/
-#line 933 "./ctangle.w"
+#line 933 "ctangle.w"
 
 switch(c){
 case'+':if(*loc=='+')compress(plus_plus);break;
@@ -1234,14 +1236,14 @@ case'!':if(*loc=='=')compress(non_eq);break;
 }
 
 /*:71*/
-#line 919 "./ctangle.w"
+#line 919 "ctangle.w"
 
 return c;
 }
 }
 
 /*:69*//*83:*/
-#line 1194 "./ctangle.w"
+#line 1194 "ctangle.w"
 
 static void
 scan_repl(
@@ -1249,7 +1251,7 @@ eight_bits t)
 {
 sixteen_bits a;
 if(t==section_name){/*85:*/
-#line 1222 "./ctangle.w"
+#line 1222 "ctangle.w"
 
 store_two_bytes(0150000);
 if(changing&&include_depth==change_depth){
@@ -1264,11 +1266,11 @@ id_loc= id_first+strlen(id_first);
 app_repl(a_l%0400);}
 
 /*:85*/
-#line 1200 "./ctangle.w"
+#line 1200 "ctangle.w"
 }
 while(true)switch(a= get_next()){
 /*86:*/
-#line 1235 "./ctangle.w"
+#line 1235 "ctangle.w"
 
 case identifier:a= id_lookup(id_first,id_loc,0)-name_dir;
 app_repl((a/0400)+0200);
@@ -1276,7 +1278,7 @@ app_repl(a%0400);break;
 case section_name:if(t!=section_name)goto done;
 else{
 /*87:*/
-#line 1268 "./ctangle.w"
+#line 1268 "ctangle.w"
 {
 char*try_loc= loc;
 while(*try_loc==' '&&try_loc<limit)try_loc++;
@@ -1289,13 +1291,13 @@ if(*try_loc=='=')err_print("! Missing `@ ' before a named section");
 }
 
 /*:87*/
-#line 1241 "./ctangle.w"
+#line 1241 "ctangle.w"
 
 a= cur_section_name-name_dir;
 app_repl((a/0400)+0250);
 app_repl(a%0400);
 /*85:*/
-#line 1222 "./ctangle.w"
+#line 1222 "ctangle.w"
 
 store_two_bytes(0150000);
 if(changing&&include_depth==change_depth){
@@ -1310,7 +1312,7 @@ id_loc= id_first+strlen(id_first);
 app_repl(a_l%0400);}
 
 /*:85*/
-#line 1245 "./ctangle.w"
+#line 1245 "ctangle.w"
 break;
 }
 case output_defs_code:if(t!=section_name)err_print("! Misplaced @h");
@@ -1321,7 +1323,7 @@ a= output_defs_flag;
 app_repl((a/0400)+0200);
 app_repl(a%0400);
 /*85:*/
-#line 1222 "./ctangle.w"
+#line 1222 "ctangle.w"
 
 store_two_bytes(0150000);
 if(changing&&include_depth==change_depth){
@@ -1336,13 +1338,13 @@ id_loc= id_first+strlen(id_first);
 app_repl(a_l%0400);}
 
 /*:85*/
-#line 1254 "./ctangle.w"
+#line 1254 "ctangle.w"
 
 }
 break;
 case constant:case string:
 /*88:*/
-#line 1279 "./ctangle.w"
+#line 1286 "ctangle.w"
 
 app_repl(a);
 while(id_first<id_loc){
@@ -1351,18 +1353,18 @@ if(*(id_first+1)=='@')id_first++;
 else err_print("! Double @ should be used in string");
 
 }
-else if(a==constant&&*id_first=='\''&&flags['q'])
+else if(a==constant&&*id_first=='\''&&skip_digit_separators)
 id_first++;
 app_repl(*id_first++);
 }
 app_repl(a);break;
 
 /*:88*/
-#line 1258 "./ctangle.w"
+#line 1258 "ctangle.w"
 
 case ord:
 /*89:*/
-#line 1297 "./ctangle.w"
+#line 1304 "ctangle.w"
 {
 int c= (eight_bits)*id_first;
 if(c=='\\'){
@@ -1413,7 +1415,7 @@ app_repl(constant);
 break;
 
 /*:89*/
-#line 1260 "./ctangle.w"
+#line 1260 "ctangle.w"
 
 case definition:case format_code:case begin_C:if(t!=section_name)goto done;
 else{
@@ -1423,7 +1425,7 @@ err_print("! @d, @f and @c are ignored in C text");continue;
 case new_section:goto done;
 
 /*:86*/
-#line 1205 "./ctangle.w"
+#line 1205 "ctangle.w"
 
 case')':app_repl(a);
 if(t==macro)app_repl(' ');
@@ -1436,7 +1438,7 @@ cur_text= text_ptr;(++text_ptr)->tok_start= tok_ptr;
 }
 
 /*:83*//*90:*/
-#line 1356 "./ctangle.w"
+#line 1363 "ctangle.w"
 
 static void
 scan_section(void)
@@ -1451,7 +1453,7 @@ printf("*%d",section_count);update_terminal;
 next_control= 0;
 while(true){
 /*92:*/
-#line 1397 "./ctangle.w"
+#line 1404 "ctangle.w"
 
 while(next_control<definition)
 
@@ -1460,11 +1462,11 @@ loc-= 2;next_control= get_next();
 }
 
 /*:92*/
-#line 1370 "./ctangle.w"
+#line 1377 "ctangle.w"
 
 if(next_control==definition){
 /*93:*/
-#line 1404 "./ctangle.w"
+#line 1411 "ctangle.w"
 {
 while((next_control= get_next())=='\n');
 if(next_control!=identifier){
@@ -1483,7 +1485,7 @@ cur_text->text_link= macro;
 }
 
 /*:93*/
-#line 1372 "./ctangle.w"
+#line 1379 "ctangle.w"
 
 continue;
 }
@@ -1493,14 +1495,14 @@ p= name_dir;break;
 if(next_control==section_name){
 p= cur_section_name;
 /*94:*/
-#line 1429 "./ctangle.w"
+#line 1436 "ctangle.w"
 
 while((next_control= get_next())=='+');
 if(next_control!='='&&next_control!=eq_eq)
 continue;
 
 /*:94*/
-#line 1380 "./ctangle.w"
+#line 1387 "ctangle.w"
 
 break;
 }
@@ -1508,20 +1510,20 @@ return;
 }
 no_where= print_where= false;
 /*95:*/
-#line 1434 "./ctangle.w"
+#line 1441 "ctangle.w"
 
 /*96:*/
-#line 1439 "./ctangle.w"
+#line 1446 "ctangle.w"
 
 store_two_bytes((sixteen_bits)(0150000+section_count));
 
 
 /*:96*/
-#line 1435 "./ctangle.w"
+#line 1442 "ctangle.w"
 
 scan_repl(section_name);
 /*97:*/
-#line 1443 "./ctangle.w"
+#line 1450 "ctangle.w"
 
 if(p==name_dir||p==NULL){
 (last_unnamed)->text_link= cur_text-text_info;last_unnamed= cur_text;
@@ -1538,16 +1540,16 @@ cur_text->text_link= section_flag;
 
 
 /*:97*/
-#line 1437 "./ctangle.w"
+#line 1444 "ctangle.w"
 
 
 /*:95*/
-#line 1386 "./ctangle.w"
+#line 1393 "ctangle.w"
 
 }
 
 /*:90*//*98:*/
-#line 1458 "./ctangle.w"
+#line 1465 "ctangle.w"
 
 static void
 phase_one(void){
@@ -1561,7 +1563,7 @@ phase= 2;
 }
 
 /*:98*//*100:*/
-#line 1475 "./ctangle.w"
+#line 1482 "ctangle.w"
 
 static void
 skip_limbo(void)
@@ -1576,7 +1578,7 @@ c= *loc++;
 if(ccode[(eight_bits)c]==new_section)break;
 switch(ccode[(eight_bits)c]){
 case translit_code:/*102:*/
-#line 1506 "./ctangle.w"
+#line 1513 "ctangle.w"
 
 while(xisspace(*loc)&&loc<limit)loc++;
 loc+= 3;
@@ -1601,7 +1603,7 @@ translit[i-0200][loc-beg]= '\0';
 }
 
 /*:102*/
-#line 1488 "./ctangle.w"
+#line 1495 "ctangle.w"
 break;
 case format_code:case'@':break;
 case control_text:if(c=='q'||c=='Q'){
@@ -1619,7 +1621,7 @@ default:err_print("! Double @ should be used in limbo");
 }
 
 /*:100*//*103:*/
-#line 1532 "./ctangle.w"
+#line 1539 "ctangle.w"
 
 void
 print_stats(void){

--- a/ctangle.w
+++ b/ctangle.w
@@ -151,11 +151,11 @@ init_node(name_dir); /* the undefined section has no replacement text */
 starting at position |first| equals the identifier pointed to by |p|:
 
 @c
-boolean names_match(@t\1\1@>
+boolean names_match(
 name_pointer p, /* points to the proposed match */
 const char *first, /* position of first character of string */
 size_t l, /* length of identifier */
-eight_bits t@t\2\2@>) /* not used by \.{TANGLE} */
+eight_bits t) /* not used by \.{TANGLE} */
 {@+(void)t;
   if (length(p)!=l) return false;
   return !strncmp(first,p->byte_start,l);
@@ -312,8 +312,8 @@ We assume that the \CEE/ compiler can copy structures.
 
 @c
 static void
-push_level(@t\1\1@> /* suspends the current level */
-name_pointer p@t\2\2@>)
+push_level(/* suspends the current level */
+name_pointer p)
 {
   if (stack_ptr==stack_end) overflow("stack");
   *stack_ptr=cur_state;
@@ -335,8 +335,8 @@ text or returns the state to the most recently stacked level.
 
 @c
 static void
-pop_level(@t\1\1@> /* do this when |cur_byte| reaches |cur_end| */
-boolean flag@t\2\2@>) /* |flag==false| means we are in |output_defs| */
+pop_level(/* do this when |cur_byte| reaches |cur_end| */
+boolean flag) /* |flag==false| means we are in |output_defs| */
 {
   if (flag && cur_repl->text_link<section_flag) { /* link to a continuation */
     cur_repl=cur_repl->text_link+text_info; /* stay on the same level */
@@ -838,8 +838,8 @@ No comment, long or short, is allowed to contain `\.{@@\ }' or `\.{@@*}'.
 static boolean comment_continues=false; /* are we scanning a comment? */
 
 @ @c
-static boolean skip_comment(@t\1\1@> /* skips over comments */
-boolean is_long_comment@t\2\2@>)
+static boolean skip_comment(/* skips over comments */
+boolean is_long_comment)
 {
   char c; /* current character */
   while (true) {
@@ -1193,8 +1193,8 @@ static eight_bits next_control;
 
 @ @c
 static void
-scan_repl(@t\1\1@> /* creates a replacement text */
-eight_bits t@t\2\2@>)
+scan_repl(/* creates a replacement text */
+eight_bits t)
 {
   sixteen_bits a; /* the current token */
   if (t==section_name) {@<Insert the line number into |tok_mem|@>@;}

--- a/ctangle.w
+++ b/ctangle.w
@@ -151,11 +151,11 @@ init_node(name_dir); /* the undefined section has no replacement text */
 starting at position |first| equals the identifier pointed to by |p|:
 
 @c
-boolean names_match(
+boolean names_match(@t\1\1@>
 name_pointer p, /* points to the proposed match */
 const char *first, /* position of first character of string */
 size_t l, /* length of identifier */
-eight_bits t) /* not used by \.{TANGLE} */
+eight_bits t@t\2\2@>) /* not used by \.{TANGLE} */
 {@+(void)t;
   if (length(p)!=l) return false;
   return !strncmp(first,p->byte_start,l);
@@ -312,8 +312,8 @@ We assume that the \CEE/ compiler can copy structures.
 
 @c
 static void
-push_level(/* suspends the current level */
-name_pointer p)
+push_level(@t\1\1@> /* suspends the current level */
+name_pointer p@t\2\2@>)
 {
   if (stack_ptr==stack_end) overflow("stack");
   *stack_ptr=cur_state;
@@ -335,8 +335,8 @@ text or returns the state to the most recently stacked level.
 
 @c
 static void
-pop_level(/* do this when |cur_byte| reaches |cur_end| */
-boolean flag) /* |flag==false| means we are in |output_defs| */
+pop_level(@t\1\1@> /* do this when |cur_byte| reaches |cur_end| */
+boolean flag@t\2\2@>) /* |flag==false| means we are in |output_defs| */
 {
   if (flag && cur_repl->text_link<section_flag) { /* link to a continuation */
     cur_repl=cur_repl->text_link+text_info; /* stay on the same level */
@@ -838,8 +838,8 @@ No comment, long or short, is allowed to contain `\.{@@\ }' or `\.{@@*}'.
 static boolean comment_continues=false; /* are we scanning a comment? */
 
 @ @c
-static boolean skip_comment(/* skips over comments */
-boolean is_long_comment)
+static boolean skip_comment(@t\1\1@> /* skips over comments */
+boolean is_long_comment@t\2\2@>)
 {
   char c; /* current character */
   while (true) {
@@ -1193,8 +1193,8 @@ static eight_bits next_control;
 
 @ @c
 static void
-scan_repl(/* creates a replacement text */
-eight_bits t)
+scan_repl(@t\1\1@> /* creates a replacement text */
+eight_bits t@t\2\2@>)
 {
   sixteen_bits a; /* the current token */
   if (t==section_name) {@<Insert the line number into |tok_mem|@>@;}

--- a/ctangle.w
+++ b/ctangle.w
@@ -1276,7 +1276,14 @@ case new_section: goto done;
      as explained in the manual */
 }
 
-@ @<Copy a string...@>=
+@ By default, \.{CTANGLE} copies \CPLUSPLUS/-style literals (e.g., |1'000'000|)
+verbatim. The \.{+k} switch will cause the single quotes to be skipped---for
+\CPLUSPLUS/ this has no effect, but it allows the use of such literals in \CEE/
+code.
+
+@d skip_digit_separators flags['k']
+
+@<Copy a string...@>=
   app_repl(a); /* |string| or |constant| */
   while (id_first < id_loc) { /* simplify \.{@@@@} pairs */
     if (*id_first=='@@') {
@@ -1284,7 +1291,7 @@ case new_section: goto done;
       else err_print("! Double @@ should be used in string");
 @.Double @@ should be used...@>
     }
-    else if (a==constant && *id_first=='\'' && flags['q'])
+    else if (a==constant && *id_first=='\'' && skip_digit_separators)
       id_first++;
     app_repl(*id_first++);
   }

--- a/ctangle.w
+++ b/ctangle.w
@@ -960,24 +960,33 @@ switch(c) {
 }
 
 @ @<Get a constant@>= {
+  boolean hex_flag = false; /* are we reading a hexadecimal literal? */
   id_first=loc-1;
   if (*id_first=='.' && !xisdigit(*loc)) goto mistake; /* not a constant */
   if (*id_first=='0') {
     if (*loc=='x' || *loc=='X') { /* hex constant */
-      loc++; while (xisxdigit(*loc)) loc++; goto found;
+      hex_flag = true;
+      loc++; while (xisxdigit(*loc) || *loc=='\'') loc++;
+    }
+    else if (*loc=='b' || *loc=='B') { /* binary constant */
+      loc++; while (*loc=='0' || *loc=='1' || *loc=='\'') loc++; goto found;
     }
   }
-  while (xisdigit(*loc)) loc++;
+  while (xisdigit(*loc) || *loc=='\'') loc++;
   if (*loc=='.') {
   loc++;
-  while (xisdigit(*loc)) loc++;
+  while ((hex_flag && xisxdigit(*loc)) || xisdigit(*loc) || *loc=='\'') loc++;
   }
   if (*loc=='e' || *loc=='E') { /* float constant */
     if (*++loc=='+' || *loc=='-') loc++;
-    while (xisdigit(*loc)) loc++;
+    while (xisdigit(*loc) || *loc=='\'') loc++;
   }
- found: while (*loc=='u' || *loc=='U' || *loc=='l' || *loc=='L'
-             || *loc=='f' || *loc=='F') loc++;
+  else if (hex_flag && (*loc=='p' || *loc=='P')) { /* hex float constant */
+    if (*++loc=='+' || *loc=='-') loc++;
+    while (xisxdigit(*loc) || *loc=='\'') loc++;
+  }
+found: while (*loc=='u' || *loc=='U' || *loc=='l' || *loc=='L'
+            || *loc=='f' || *loc=='F') loc++;
   id_loc=loc;
   return constant;
 }
@@ -1275,6 +1284,8 @@ case new_section: goto done;
       else err_print("! Double @@ should be used in string");
 @.Double @@ should be used...@>
     }
+    else if (a==constant && *id_first=='\'' && flags['q'])
+      id_first++;
     app_repl(*id_first++);
   }
   app_repl(a); break;

--- a/cweave.w
+++ b/cweave.w
@@ -85,9 +85,9 @@ Please read the documentation for \.{common}, the set of routines common
 to \.{CTANGLE} and \.{CWEAVE}, before proceeding further.
 
 @c
-int main (
+int main (@t\1\1@>
 int ac, /* argument count */
-char **av) /* argument values */
+char **av@t\2\2@>) /* argument values */
 {
   argc=ac; argv=av;
   program=cweave;
@@ -354,11 +354,11 @@ text_ptr=max_text_ptr=tok_start+1;
 
 @ Here are the three procedures needed to complete |id_lookup|:
 @c
-boolean names_match(
+boolean names_match(@t\1\1@>
 name_pointer p, /* points to the proposed match */
 const char *first, /* position of first character of string */
 size_t l, /* length of identifier */
-eight_bits t) /* desired |ilk| */
+eight_bits t@t\2\2@>) /* desired |ilk| */
 {
   if (length(p)!=l) return false;
   if (p->ilk!=t && !(t==normal && abnormal(p))) return false;
@@ -1122,8 +1122,8 @@ static void outer_xref(void);
 
 @ @c
 static void
-C_xref(/* makes cross-references for \CEE/ identifiers */
-  eight_bits spec_ctrl)
+C_xref(@t\1\1@> /* makes cross-references for \CEE/ identifiers */
+  eight_bits spec_ctrl@t\2\2@>)
 {
   name_pointer p; /* a referenced name */
   while (next_control<format_code || next_control==spec_ctrl) {
@@ -1368,9 +1368,9 @@ static void finish_line(void);
 
 @ @c
 static void
-flush_buffer(
+flush_buffer(@t\1\1@>
 char *b, /* outputs from |out_buf+1| to |b|, where |b<=out_ptr| */
-boolean per_cent,boolean carryover)
+boolean per_cent,boolean carryover@t\2\2@>)
 {
   char *j; j=b; /* pointer into |out_buf| */
   if (! per_cent) /* remove trailing blanks */
@@ -1433,8 +1433,8 @@ static void break_out(void);
 
 @ @c
 static void
-out_str(/* output characters from |s| to end of string */
-const char*s)
+out_str(@t\1\1@> /* output characters from |s| to end of string */
+const char*s@t\2\2@>)
 {
   while (*s) out(*s++);
 }
@@ -1601,9 +1601,9 @@ one further token without overflow.
 @d app_tok(c) {if (tok_ptr+2>tok_mem_end) overflow("token"); *(tok_ptr++)=c;}
 
 @c
-static int copy_comment(/* copies \TeX\ code in comments */
+static int copy_comment(@t\1\1@> /* copies \TeX\ code in comments */
 boolean is_long_comment, /* is this a traditional \CEE/ comment? */
-int bal) /* brace balance */
+int bal@t\2\2@>) /* brace balance */
 {
   char c; /* current character being copied */
   while (true) {
@@ -1845,8 +1845,8 @@ static char cat_name[256][12];
 
 @c
 static void
-print_cat(/* symbolic printout of a category */
-eight_bits c)
+print_cat(@t\1\1@> /* symbolic printout of a category */
+eight_bits c@t\2\2@>)
 {
   fputs(cat_name[c],stdout);
 }
@@ -2232,8 +2232,8 @@ translated without line-break controls.
 
 @c
 static void
-print_text(/* prints a token list for debugging; not used in |main| */
-text_pointer p)
+print_text(@t\1\1@> /* prints a token list for debugging; not used in |main| */
+text_pointer p@t\2\2@>)
 {
   token_pointer j; /* index into |tok_mem| */
   sixteen_bits r; /* remainder of token after the flag has been stripped off */
@@ -2560,8 +2560,8 @@ the |for| loop below.
 
 @c
 static void
-make_reserved(/* make the first identifier in |p->trans| like |int| */
-scrap_pointer p)
+make_reserved(@t\1\1@> /* make the first identifier in |p->trans| like |int| */
+scrap_pointer p@t\2\2@>)
 {
   sixteen_bits tok_value; /* the name of this identifier, plus its flag */
   token_pointer tok_loc; /* pointer to |tok_value| */
@@ -2591,9 +2591,9 @@ it has been swallowed up by an |exp|.
 
 @c
 static void
-make_underlined(
+make_underlined(@t\1\1@>
 /* underline the entry for the first identifier in |p->trans| */
-scrap_pointer p)
+scrap_pointer p@t\2\2@>)
 {
   token_pointer tok_loc; /* where the first identifier appears */
   if ((tok_loc=find_first_ident(p->trans))<=operator_found)
@@ -3408,8 +3408,8 @@ is advanced.
 
 @c
 static void
-C_parse(/* creates scraps from \CEE/ tokens */
-  eight_bits spec_ctrl)
+C_parse(@t\1\1@> /* creates scraps from \CEE/ tokens */
+  eight_bits spec_ctrl@t\2\2@>)
 {
   int count; /* characters remaining before string break */
   while (next_control<format_code || next_control==spec_ctrl) {
@@ -3649,8 +3649,8 @@ static void outer_parse(void);
 
 @ @c
 static void
-app_cur_id(
-boolean scrapping) /* are we making this into a scrap? */
+app_cur_id(@t\1\1@>
+boolean scrapping@t\2\2@>) /* are we making this into a scrap? */
 {
   name_pointer p=id_lookup(id_first,id_loc,normal);
   if (p->ilk<=custom) { /* not a reserved word */
@@ -3816,8 +3816,8 @@ static void pop_level(void);
 
 @ @c
 static void
-push_level(/* suspends the current level */
-text_pointer p)
+push_level(@t\1\1@> /* suspends the current level */
+text_pointer p@t\2\2@>)
 {
   if (stack_ptr==stack_end) overflow("stack");
   if (stack_ptr>stack) { /* save current state */
@@ -4306,8 +4306,8 @@ takes place, so that the translation will normally end with \.{\\6} or
 
 @c
 static void
-finish_C(/* finishes a definition or a \CEE/ part */
-  boolean visible) /* |true| if we should produce \TeX\ output */
+finish_C(@t\1\1@> /* finishes a definition or a \CEE/ part */
+  boolean visible@t\2\2@>) /* |true| if we should produce \TeX\ output */
 {
   text_pointer p; /* translation of the scraps */
   if (visible) {
@@ -4485,8 +4485,8 @@ supply new definitions for the macros \.{\\A}, \.{\\As}, etc.
 
 @c
 static void
-footnote(/* outputs section cross-references */
-sixteen_bits flag)
+footnote(@t\1\1@> /* outputs section cross-references */
+sixteen_bits flag@t\2\2@>)
 {
   xref_pointer q; /* cross-reference pointer variable */
   if (cur_xref->num<=flag) return;
@@ -4727,8 +4727,8 @@ regarded as identical.
 
 @c
 static void
-unbucket(/* empties buckets having depth |d| */
-eight_bits d)
+unbucket(@t\1\1@> /* empties buckets having depth |d| */
+eight_bits d@t\2\2@>)
 {
   int c; /* index into |bucket|; cannot be a simple |char| because of sign
     comparison below */
@@ -4846,8 +4846,8 @@ prints them.
 
 @c
 static void
-section_print(/* print all section names in subtree |p| */
-name_pointer p)
+section_print(@t\1\1@> /* print all section names in subtree |p| */
+name_pointer p@t\2\2@>)
 {
   if (p) {
     section_print(p->llink); out_str("\\I");

--- a/cweave.w
+++ b/cweave.w
@@ -3029,8 +3029,7 @@ else if (cat1==exp || cat1==raw_int) {
 }
 else if (cat1==cast && cat2==struct_like) {
   big_app1_insert(pp,' '); reduce(pp,2,struct_like,0,155);
-}@+
-else squash(pp,1,raw_int,0,91);
+}@+ else squash(pp,1,raw_int,0,91);
 
 @ @<Cases for |new_like|@>=
 if (cat1==lpar && cat2==exp && cat3==rpar) squash(pp,4,new_like,0,92);

--- a/cweave.w
+++ b/cweave.w
@@ -178,11 +178,7 @@ formatted.
 @d template_like 58 /* \&{template} */
 @d alignas_like 59 /* \&{alignas} */
 @d using_like 60 /* \&{using} */
-<<<<<<< df2f4823d4229e96f39ffe5791b18e16b93b924f
 @d default_like 61 /* \&{default} */
-=======
-@d default_like 61 /* \&{using} */
->>>>>>> Update CWEAVE
 @d attr 62 /* \&{noexcept} and attributes */
 
 @ We keep track of the current section number in |section_count|, which
@@ -858,12 +854,8 @@ are pointers into the array |section_text|, not into |buffer|.
       *id_loc++='/';
       goto digit_suffix;
     }
-<<<<<<< df2f4823d4229e96f39ffe5791b18e16b93b924f
     else if (xisdigit(*loc)) { /* octal constant */
       *id_loc++='~';
-=======
-    else if (xisdigit(*loc)) {*id_loc++='~'; /* octal constant */
->>>>>>> Update CWEAVE
       gather_digits_while(xisdigit(*loc));
       *id_loc++='/';
       goto digit_suffix;
@@ -1773,13 +1765,8 @@ same initial letter; these subscripts are assigned from left to right.
 @d new_exp 64 /* \&{new} and a following type identifier */
 @d begin_arg 65 /* \.{@@[} */
 @d end_arg 66 /* \.{@@]} */
-<<<<<<< df2f4823d4229e96f39ffe5791b18e16b93b924f
 @d lbrack 67 /* denotes a left bracket */
 @d rbrack 68 /* denotes a right bracket */
-=======
-@d lbrack 67 /* \.{[} */
-@d rbrack 68 /* \.{]} */
->>>>>>> Update CWEAVE
 @d attr_head 69 /* denotes beginning of attribute */
 
 @<Private...@>=
@@ -2689,11 +2676,7 @@ else if (cat1==cast && (cat2==const_like || cat2==case_like)) {
 }
 else if (cat1==exp || cat1==cast) squash(pp,2,exp,-2,10);
 else if (cat1==attr) {
-<<<<<<< df2f4823d4229e96f39ffe5791b18e16b93b924f
   big_app1_insert(pp,' ');
-=======
-  big_app1(pp); big_app(' '); big_app1(pp+1);
->>>>>>> Update CWEAVE
   reduce(pp,2,exp,-2,142);
 }
 else if (cat1==colcol && cat2==int_like) squash(pp,3,int_like,-2,152);
@@ -2789,11 +2772,7 @@ else if (cat1==lbrace || cat1==int_like || cat1==decl) {
 }
 else if (cat1==semi) squash(pp,2,decl,-1,39);
 else if (cat1==attr) {
-<<<<<<< df2f4823d4229e96f39ffe5791b18e16b93b924f
   big_app1_insert(pp,' ');
-=======
-  big_app1(pp); big_app(' '); big_app1(pp+1);
->>>>>>> Update CWEAVE
   reduce(pp,2,decl_head,-1,139);
 }
 
@@ -2836,19 +2815,11 @@ else if (cat1==exp||cat1==int_like) {
   }
 }
 else if (cat1==attr) {
-<<<<<<< df2f4823d4229e96f39ffe5791b18e16b93b924f
   big_app1_insert(pp,' ');
   reduce(pp,2,struct_like,-3,141);
 }
 else if (cat1==struct_like) {
   big_app1_insert(pp,' ');
-=======
-  big_app1(pp); big_app(' '); big_app1(pp+1);
-  reduce(pp,2,struct_like,-3,141);
-}
-else if (cat1==struct_like) {
-  big_app1(pp); big_app(' '); big_app1(pp+1);
->>>>>>> Update CWEAVE
   reduce(pp,2,struct_like,-3,151);
 }
 
@@ -2873,11 +2844,7 @@ else if (cat1==stmt) {
   big_app1(pp+1); reduce(pp,2,function,-1,52);
 }
 else if (cat1==attr) {
-<<<<<<< df2f4823d4229e96f39ffe5791b18e16b93b924f
   big_app1_insert(pp,' ');
-=======
-  big_app1(pp); big_app(' '); big_app1(pp+1);
->>>>>>> Update CWEAVE
   reduce(pp,2,fn_decl,0,157);
 }
 
@@ -2936,11 +2903,7 @@ else if (cat1==stmt) {
   else squash(pp,1,else_like,0,65);
 }
 else if (cat1==attr) {
-<<<<<<< df2f4823d4229e96f39ffe5791b18e16b93b924f
   big_app1_insert(pp,' ');
-=======
-  big_app1(pp); big_app(' '); big_app1(pp+1);
->>>>>>> Update CWEAVE
   reduce(pp,2,if_head,0,146);
 }
 
@@ -3060,14 +3023,9 @@ else if (cat1==decl_head || cat1==int_like || cat1==exp) {
 }
 else if (cat1==struct_like) {
   if ((cat2==exp || cat2==int_like) && (cat3==comma || cat3==prerangle)) {
-<<<<<<< df2f4823d4229e96f39ffe5791b18e16b93b924f
     make_underlined(pp+2);
     if (reserve_typenames) {
       make_reserved(pp+2);
-=======
-    if (flags['t']) {
-      make_underlined(pp+2); make_reserved(pp+2);
->>>>>>> Update CWEAVE
     }
     big_app2(pp); big_app(' '); big_app2(pp+2);
     if (cat3==comma) reduce(pp,4,langle,0,153);
@@ -3081,14 +3039,8 @@ else if (cat1==exp || cat1==raw_int) {
   big_app1_insert(pp,' '); reduce(pp,2,cat1,-2,90);
 }
 else if (cat1==cast && cat2==struct_like) {
-<<<<<<< df2f4823d4229e96f39ffe5791b18e16b93b924f
   big_app1_insert(pp,' '); reduce(pp,2,struct_like,0,155);
 }@+ else squash(pp,1,raw_int,0,91);
-=======
-  big_app1(pp); big_app(' '); big_app2(pp+1); reduce(pp,2,struct_like,0,155);
-}
-else squash(pp,1,raw_int,0,91);
->>>>>>> Update CWEAVE
 
 @ @<Cases for |new_like|@>=
 if (cat1==lpar && cat2==exp && cat3==rpar) squash(pp,4,new_like,0,92);
@@ -3137,14 +3089,10 @@ squash(pp,1,int_like,-2,105);
 if (cat1==prelangle) squash(pp+1,1,langle,1,106);
 else if (cat1==colcol) squash(pp,2,colcol,-1,107);
 else if (cat1==cast) squash(pp,2,raw_int,0,108);
-<<<<<<< df2f4823d4229e96f39ffe5791b18e16b93b924f
 else if (cat1==lpar) squash(pp,1,exp,-2,109);
 else if (cat1==lbrack) squash(pp,1,exp,-2,144);
-=======
-else if (cat1==lpar||cat1==lbrack) squash(pp,1,exp,-2,109);
->>>>>>> Update CWEAVE
+else if (cat1==lpar) squash(pp,1,exp,-2,109);
 else if (cat1!=langle) squash(pp,1,int_like,-3,110);
-else if (cat1==lbrack) squash(pp,1,exp,-2,144);
 
 @ @<Cases for |operator_like|@>=
 if (cat1==binop || cat1==unop || cat1==ubinop) {
@@ -3220,25 +3168,16 @@ else if (cat1==comma)
 
 @ @<Cases for |attr|@>=
 if (cat1==lbrace || cat1==stmt) {
-<<<<<<< df2f4823d4229e96f39ffe5791b18e16b93b924f
   big_app1_insert(pp,' ');
   reduce(pp,2,cat1,-2,134);
 }
 else if (cat1==tag) {
   big_app1_insert(pp,' ');
-=======
-  big_app1(pp); big_app(' '); big_app1(pp+1);
-  reduce(pp,2,cat1,-2,134);
-}
-else if (cat1==tag) {
-  big_app1(pp); big_app(' '); big_app1(pp+1);
->>>>>>> Update CWEAVE
   reduce(pp,2,tag,-1,135);
 }
 else if (cat1==semi)
   squash(pp,2,stmt,-2,136);
 else if (cat1==attr) {
-<<<<<<< df2f4823d4229e96f39ffe5791b18e16b93b924f
   big_app1_insert(pp,' ');
   reduce(pp,2,attr,-1,137);
 }
@@ -3252,21 +3191,6 @@ else if (cat1==typedef_like) {
 }
 else if (cat1==function) {
   big_app1_insert(pp,' ');
-=======
-  big_app1(pp); big_app(' '); big_app1(pp+1);
-  reduce(pp,2,attr,-1,137);
-}
-else if (cat1==decl_head) {
-  big_app1(pp); big_app(' '); big_app1(pp+1);
-  reduce(pp,2,decl_head,-1,138);
-}
-else if (cat1==typedef_like) {
-  big_app1(pp); big_app(' '); big_app1(pp+1);
-  reduce(pp,2,typedef_like,0,143);
-}
-else if (cat1==function) {
-  big_app1(pp); big_app(' '); big_app1(pp+1);
->>>>>>> Update CWEAVE
   reduce(pp,2,function,-1,148);
 }
 

--- a/cweave.w
+++ b/cweave.w
@@ -2947,7 +2947,7 @@ else if (cat1==stmt||cat1==decl||cat1==function) {
   big_app1_insert(pp,break_space);
   reduce(pp,2,cat1,-1,75);
 }
-else squash(pp,1,decl,-1,156);
+else if (cat1==rbrace) squash(pp,1,decl,-1,156);
 
 @ The user can decide at run-time whether short statements should be
 grouped together on the same line.
@@ -3194,7 +3194,7 @@ else if (cat1==function) {
 }
 
 @ @<Cases for |default_like|@>=
-if (cat1==colon) squash(pp,2,case_like,-3,149);
+if (cat1==colon) squash(pp,1,case_like,-3,149);
 else squash(pp,1,exp,-2,150);
 
 @ Now here's the |reduce| procedure used in our code for productions.

--- a/cweave.w
+++ b/cweave.w
@@ -178,7 +178,11 @@ formatted.
 @d template_like 58 /* \&{template} */
 @d alignas_like 59 /* \&{alignas} */
 @d using_like 60 /* \&{using} */
+<<<<<<< df2f4823d4229e96f39ffe5791b18e16b93b924f
 @d default_like 61 /* \&{default} */
+=======
+@d default_like 61 /* \&{using} */
+>>>>>>> Update CWEAVE
 @d attr 62 /* \&{noexcept} and attributes */
 
 @ We keep track of the current section number in |section_count|, which
@@ -854,8 +858,12 @@ are pointers into the array |section_text|, not into |buffer|.
       *id_loc++='/';
       goto digit_suffix;
     }
+<<<<<<< df2f4823d4229e96f39ffe5791b18e16b93b924f
     else if (xisdigit(*loc)) { /* octal constant */
       *id_loc++='~';
+=======
+    else if (xisdigit(*loc)) {*id_loc++='~'; /* octal constant */
+>>>>>>> Update CWEAVE
       gather_digits_while(xisdigit(*loc));
       *id_loc++='/';
       goto digit_suffix;
@@ -1765,8 +1773,13 @@ same initial letter; these subscripts are assigned from left to right.
 @d new_exp 64 /* \&{new} and a following type identifier */
 @d begin_arg 65 /* \.{@@[} */
 @d end_arg 66 /* \.{@@]} */
+<<<<<<< df2f4823d4229e96f39ffe5791b18e16b93b924f
 @d lbrack 67 /* denotes a left bracket */
 @d rbrack 68 /* denotes a right bracket */
+=======
+@d lbrack 67 /* \.{[} */
+@d rbrack 68 /* \.{]} */
+>>>>>>> Update CWEAVE
 @d attr_head 69 /* denotes beginning of attribute */
 
 @<Private...@>=
@@ -2676,7 +2689,11 @@ else if (cat1==cast && (cat2==const_like || cat2==case_like)) {
 }
 else if (cat1==exp || cat1==cast) squash(pp,2,exp,-2,10);
 else if (cat1==attr) {
+<<<<<<< df2f4823d4229e96f39ffe5791b18e16b93b924f
   big_app1_insert(pp,' ');
+=======
+  big_app1(pp); big_app(' '); big_app1(pp+1);
+>>>>>>> Update CWEAVE
   reduce(pp,2,exp,-2,142);
 }
 else if (cat1==colcol && cat2==int_like) squash(pp,3,int_like,-2,152);
@@ -2772,7 +2789,11 @@ else if (cat1==lbrace || cat1==int_like || cat1==decl) {
 }
 else if (cat1==semi) squash(pp,2,decl,-1,39);
 else if (cat1==attr) {
+<<<<<<< df2f4823d4229e96f39ffe5791b18e16b93b924f
   big_app1_insert(pp,' ');
+=======
+  big_app1(pp); big_app(' '); big_app1(pp+1);
+>>>>>>> Update CWEAVE
   reduce(pp,2,decl_head,-1,139);
 }
 
@@ -2815,11 +2836,19 @@ else if (cat1==exp||cat1==int_like) {
   }
 }
 else if (cat1==attr) {
+<<<<<<< df2f4823d4229e96f39ffe5791b18e16b93b924f
   big_app1_insert(pp,' ');
   reduce(pp,2,struct_like,-3,141);
 }
 else if (cat1==struct_like) {
   big_app1_insert(pp,' ');
+=======
+  big_app1(pp); big_app(' '); big_app1(pp+1);
+  reduce(pp,2,struct_like,-3,141);
+}
+else if (cat1==struct_like) {
+  big_app1(pp); big_app(' '); big_app1(pp+1);
+>>>>>>> Update CWEAVE
   reduce(pp,2,struct_like,-3,151);
 }
 
@@ -2844,7 +2873,11 @@ else if (cat1==stmt) {
   big_app1(pp+1); reduce(pp,2,function,-1,52);
 }
 else if (cat1==attr) {
+<<<<<<< df2f4823d4229e96f39ffe5791b18e16b93b924f
   big_app1_insert(pp,' ');
+=======
+  big_app1(pp); big_app(' '); big_app1(pp+1);
+>>>>>>> Update CWEAVE
   reduce(pp,2,fn_decl,0,157);
 }
 
@@ -2903,7 +2936,11 @@ else if (cat1==stmt) {
   else squash(pp,1,else_like,0,65);
 }
 else if (cat1==attr) {
+<<<<<<< df2f4823d4229e96f39ffe5791b18e16b93b924f
   big_app1_insert(pp,' ');
+=======
+  big_app1(pp); big_app(' '); big_app1(pp+1);
+>>>>>>> Update CWEAVE
   reduce(pp,2,if_head,0,146);
 }
 
@@ -3023,9 +3060,14 @@ else if (cat1==decl_head || cat1==int_like || cat1==exp) {
 }
 else if (cat1==struct_like) {
   if ((cat2==exp || cat2==int_like) && (cat3==comma || cat3==prerangle)) {
+<<<<<<< df2f4823d4229e96f39ffe5791b18e16b93b924f
     make_underlined(pp+2);
     if (reserve_typenames) {
       make_reserved(pp+2);
+=======
+    if (flags['t']) {
+      make_underlined(pp+2); make_reserved(pp+2);
+>>>>>>> Update CWEAVE
     }
     big_app2(pp); big_app(' '); big_app2(pp+2);
     if (cat3==comma) reduce(pp,4,langle,0,153);
@@ -3039,8 +3081,14 @@ else if (cat1==exp || cat1==raw_int) {
   big_app1_insert(pp,' '); reduce(pp,2,cat1,-2,90);
 }
 else if (cat1==cast && cat2==struct_like) {
+<<<<<<< df2f4823d4229e96f39ffe5791b18e16b93b924f
   big_app1_insert(pp,' '); reduce(pp,2,struct_like,0,155);
 }@+ else squash(pp,1,raw_int,0,91);
+=======
+  big_app1(pp); big_app(' '); big_app2(pp+1); reduce(pp,2,struct_like,0,155);
+}
+else squash(pp,1,raw_int,0,91);
+>>>>>>> Update CWEAVE
 
 @ @<Cases for |new_like|@>=
 if (cat1==lpar && cat2==exp && cat3==rpar) squash(pp,4,new_like,0,92);
@@ -3089,9 +3137,14 @@ squash(pp,1,int_like,-2,105);
 if (cat1==prelangle) squash(pp+1,1,langle,1,106);
 else if (cat1==colcol) squash(pp,2,colcol,-1,107);
 else if (cat1==cast) squash(pp,2,raw_int,0,108);
+<<<<<<< df2f4823d4229e96f39ffe5791b18e16b93b924f
 else if (cat1==lpar) squash(pp,1,exp,-2,109);
 else if (cat1==lbrack) squash(pp,1,exp,-2,144);
+=======
+else if (cat1==lpar||cat1==lbrack) squash(pp,1,exp,-2,109);
+>>>>>>> Update CWEAVE
 else if (cat1!=langle) squash(pp,1,int_like,-3,110);
+else if (cat1==lbrack) squash(pp,1,exp,-2,144);
 
 @ @<Cases for |operator_like|@>=
 if (cat1==binop || cat1==unop || cat1==ubinop) {
@@ -3167,16 +3220,25 @@ else if (cat1==comma)
 
 @ @<Cases for |attr|@>=
 if (cat1==lbrace || cat1==stmt) {
+<<<<<<< df2f4823d4229e96f39ffe5791b18e16b93b924f
   big_app1_insert(pp,' ');
   reduce(pp,2,cat1,-2,134);
 }
 else if (cat1==tag) {
   big_app1_insert(pp,' ');
+=======
+  big_app1(pp); big_app(' '); big_app1(pp+1);
+  reduce(pp,2,cat1,-2,134);
+}
+else if (cat1==tag) {
+  big_app1(pp); big_app(' '); big_app1(pp+1);
+>>>>>>> Update CWEAVE
   reduce(pp,2,tag,-1,135);
 }
 else if (cat1==semi)
   squash(pp,2,stmt,-2,136);
 else if (cat1==attr) {
+<<<<<<< df2f4823d4229e96f39ffe5791b18e16b93b924f
   big_app1_insert(pp,' ');
   reduce(pp,2,attr,-1,137);
 }
@@ -3190,6 +3252,21 @@ else if (cat1==typedef_like) {
 }
 else if (cat1==function) {
   big_app1_insert(pp,' ');
+=======
+  big_app1(pp); big_app(' '); big_app1(pp+1);
+  reduce(pp,2,attr,-1,137);
+}
+else if (cat1==decl_head) {
+  big_app1(pp); big_app(' '); big_app1(pp+1);
+  reduce(pp,2,decl_head,-1,138);
+}
+else if (cat1==typedef_like) {
+  big_app1(pp); big_app(' '); big_app1(pp+1);
+  reduce(pp,2,typedef_like,0,143);
+}
+else if (cat1==function) {
+  big_app1(pp); big_app(' '); big_app1(pp+1);
+>>>>>>> Update CWEAVE
   reduce(pp,2,function,-1,148);
 }
 
@@ -3471,11 +3548,9 @@ switch (next_control) {
 @.\\\#@>
   case ignore: case xref_roman: case xref_wildcard:
   case xref_typewriter: case noop:@+break;
-  case '(': app_str("\\1\\1");@+app(next_control);@+app_scrap(lpar,maybe_math);@+break;
-@.\\1@>
+  case '(': app(next_control);@+app_scrap(lpar,maybe_math);@+break;
+  case ')': app(next_control);@+app_scrap(rpar,maybe_math);@+break;
   case '[': app(next_control);@+app_scrap(lbrack,maybe_math);@+break;
-  case ')': app_str("\\2\\2");@+app(next_control);@+app_scrap(rpar,maybe_math);@+break;
-@.\\2@>
   case ']': app(next_control);@+app_scrap(rbrack,maybe_math);@+break;
   case '{': app_str("\\{"@q}@>);@+app_scrap(lbrace,yes_math);@+break;
 @.\\\{@>@q}@>
@@ -4360,12 +4435,18 @@ it starts after we scan the matching `\.)'.
   reswitch: switch (next_control=get_next()) {
       case '(': case ',': app(next_control); goto reswitch;
       case identifier: app_cur_id(false); goto reswitch;
-      case ')': app(next_control); next_control=get_next(); break;
-      case dot_dot_dot: app_str("\\,\\ldots\\,"); @.\\,@> @.\\ldots@>
+      case @q(@>')': app(next_control); next_control=get_next(); break;
+      case dot_dot_dot: app_str("\\,\\ldots\\,");
+@.\\,@>
+@.\\ldots@>
         app_scrap(raw_int,no_math);
-        if ((next_control=get_next())==')') {
-          app(next_control); next_control=get_next(); break;
-        } /* otherwise fall through */
+        next_control=get_next();
+        if (next_control==')') {
+          app(next_control);
+          next_control=get_next();
+          break;
+        }
+        /* otherwise fall through */
       default: err_print("! Improper macro definition"); break;
       }
       app('$');

--- a/cweave.w
+++ b/cweave.w
@@ -3091,7 +3091,6 @@ else if (cat1==colcol) squash(pp,2,colcol,-1,107);
 else if (cat1==cast) squash(pp,2,raw_int,0,108);
 else if (cat1==lpar) squash(pp,1,exp,-2,109);
 else if (cat1==lbrack) squash(pp,1,exp,-2,144);
-else if (cat1==lpar) squash(pp,1,exp,-2,109);
 else if (cat1!=langle) squash(pp,1,int_like,-3,110);
 
 @ @<Cases for |operator_like|@>=
@@ -3472,9 +3471,9 @@ switch (next_control) {
 @.\\\#@>
   case ignore: case xref_roman: case xref_wildcard:
   case xref_typewriter: case noop:@+break;
-<<<<<<< HEAD
   case '(': app(next_control);@+app_scrap(lpar,maybe_math);@+break;
   case ')': app(next_control);@+app_scrap(rpar,maybe_math);@+break;
+  case '[': app(next_control);@+app_scrap(lbrack,maybe_math);@+break;
   case '[': app(next_control);@+app_scrap(lbrack,maybe_math);@+break;
   case ']': app(next_control);@+app_scrap(rbrack,maybe_math);@+break;
   case '{': app_str("\\{"@q}@>);@+app_scrap(lbrace,yes_math);@+break;

--- a/cweave.w
+++ b/cweave.w
@@ -2669,7 +2669,7 @@ else if (cat1==cast && (cat2==const_like || cat2==case_like)) {
 }
 else if (cat1==exp || cat1==cast) squash(pp,2,exp,-2,10);
 else if (cat1==attr) {
-  big_app1_insert(pp+1,' ');
+  big_app1_insert(pp,' ');
   reduce(pp,2,exp,-2,142);
 }
 else if (cat1==colcol && cat2==int_like) squash(pp,3,int_like,-2,152);
@@ -2765,7 +2765,7 @@ else if (cat1==lbrace || cat1==int_like || cat1==decl) {
 }
 else if (cat1==semi) squash(pp,2,decl,-1,39);
 else if (cat1==attr) {
-  big_app1_insert(pp+1,' ');
+  big_app1_insert(pp,' ');
   reduce(pp,2,decl_head,-1,139);
 }
 
@@ -2780,11 +2780,11 @@ else if (cat1==stmt || cat1==function) {
 @ @<Cases for |base|@>=
 if (cat1==int_like || cat1==exp) {
   if (cat2==comma) {
-    big_app1_insert(pp+1,' ');
+    big_app1(pp); big_app(' '); big_app2(pp+1);
     app(opt); app('9'); reduce(pp,3,base,0,42);
   }
   else if (cat2==lbrace) {
-    big_app1_insert(pp+1,' '); big_app(' '); big_app1(pp+2);
+    big_app1_insert(pp,' '); big_app(' '); big_app1(pp+2);
     reduce(pp,3,lbrace,-2,43);
   }
 }
@@ -2808,11 +2808,11 @@ else if (cat1==exp||cat1==int_like) {
   }
 }
 else if (cat1==attr) {
-  big_app1_insert(pp+1,' ');
+  big_app1_insert(pp,' ');
   reduce(pp,2,struct_like,-3,141);
 }
 else if (cat1==struct_like) {
-  big_app1_insert(pp+1,' ');
+  big_app1_insert(pp,' ');
   reduce(pp,2,struct_like,-3,151);
 }
 
@@ -2837,7 +2837,7 @@ else if (cat1==stmt) {
   big_app1(pp+1); reduce(pp,2,function,-1,52);
 }
 else if (cat1==attr) {
-  big_app1_insert(pp+1,' ');
+  big_app1_insert(pp,' ');
   reduce(pp,2,fn_decl,0,157);
 }
 
@@ -2896,7 +2896,7 @@ else if (cat1==stmt) {
   else squash(pp,1,else_like,0,65);
 }
 else if (cat1==attr) {
-  big_app1_insert(pp+1,' ');
+  big_app1_insert(pp,' ');
   reduce(pp,2,if_head,0,146);
 }
 
@@ -2971,7 +2971,7 @@ else if (cat1==rproc) {
   app(inserted); big_app2(pp); reduce(pp,2,insert,-1,79);
 } else if (cat1==exp || cat1==function) {
   if (cat2==rproc) {
-    app(inserted); big_app1_insert(pp+1,' ');
+    app(inserted); big_app1(pp); big_app(' '); big_app2(pp+1);
     reduce(pp,3,insert,-1,80);
   }
   else if (cat2==exp && cat3==rproc && cat1==exp) {
@@ -3043,7 +3043,7 @@ if (cat1==int_like || cat1==const_like) {
   big_app1_insert(pp,' '); reduce(pp,2,new_exp,0,95);
 }
 else if (cat1==struct_like && (cat2==exp || cat2==int_like)) {
-  big_app1_insert(pp+1,' '); big_app(' ');
+  big_app1_insert(pp,' '); big_app(' ');
   big_app1(pp+2); reduce(pp,3,new_exp,0,96);
 }
 else if (cat1==raw_ubin) {
@@ -3156,29 +3156,29 @@ else if (cat1==comma)
 
 @ @<Cases for |attr|@>=
 if (cat1==lbrace || cat1==stmt) {
-  big_app1_insert(pp+1,' ');
+  big_app1_insert(pp,' ');
   reduce(pp,2,cat1,-2,134);
 }
 else if (cat1==tag) {
-  big_app1_insert(pp+1,' ');
+  big_app1_insert(pp,' ');
   reduce(pp,2,tag,-1,135);
 }
 else if (cat1==semi)
   squash(pp,2,stmt,-2,136);
 else if (cat1==attr) {
-  big_app1_insert(pp+1,' ');
+  big_app1_insert(pp,' ');
   reduce(pp,2,attr,-1,137);
 }
 else if (cat1==decl_head) {
-  big_app1_insert(pp+1,' ');
+  big_app1_insert(pp,' ');
   reduce(pp,2,decl_head,-1,138);
 }
 else if (cat1==typedef_like) {
-  big_app1_insert(pp+1,' ');
+  big_app1_insert(pp,' ');
   reduce(pp,2,typedef_like,0,143);
 }
 else if (cat1==function) {
-  big_app1_insert(pp+1,' ');
+  big_app1_insert(pp,' ');
   reduce(pp,2,function,-1,148);
 }
 
@@ -3460,10 +3460,12 @@ switch (next_control) {
 @.\\\#@>
   case ignore: case xref_roman: case xref_wildcard:
   case xref_typewriter: case noop:@+break;
-  case '(': app(next_control);@+app_scrap(lpar,maybe_math);@+break;
-  case ')': app(next_control);@+app_scrap(rpar,maybe_math);@+break;
-  case '[': app(next_control);@+app_scrap(lbrack,maybe_math);@+break;
-  case ']': app(next_control);@+app_scrap(rbrack,maybe_math);@+break;
+  case '(': app_str("\\1\\1");@+app(next_control);@+app_scrap(lpar,maybe_math);@+break;
+@.\\1@>
+    case '[': app(next_control);@+app_scrap(lbrack,maybe_math);@+break;
+  case ')': app_str("\\2\\2");@+app(next_control);@+app_scrap(rpar,maybe_math);@+break;
+@.\\2@>
+    case ']': app(next_control);@+app_scrap(rbrack,maybe_math);@+break;
   case '{': app_str("\\{"@q}@>);@+app_scrap(lbrace,yes_math);@+break;
 @.\\\{@>@q}@>
   case '}': app_str(@q{@>"\\}");@+app_scrap(rbrace,yes_math);@+break;

--- a/cweave.w
+++ b/cweave.w
@@ -85,9 +85,9 @@ Please read the documentation for \.{common}, the set of routines common
 to \.{CTANGLE} and \.{CWEAVE}, before proceeding further.
 
 @c
-int main (@t\1\1@>
+int main (
 int ac, /* argument count */
-char **av@t\2\2@>) /* argument values */
+char **av) /* argument values */
 {
   argc=ac; argv=av;
   program=cweave;
@@ -354,11 +354,11 @@ text_ptr=max_text_ptr=tok_start+1;
 
 @ Here are the three procedures needed to complete |id_lookup|:
 @c
-boolean names_match(@t\1\1@>
+boolean names_match(
 name_pointer p, /* points to the proposed match */
 const char *first, /* position of first character of string */
 size_t l, /* length of identifier */
-eight_bits t@t\2\2@>) /* desired |ilk| */
+eight_bits t) /* desired |ilk| */
 {
   if (length(p)!=l) return false;
   if (p->ilk!=t && !(t==normal && abnormal(p))) return false;
@@ -1118,8 +1118,8 @@ static void outer_xref(void);
 
 @ @c
 static void
-C_xref(@t\1\1@> /* makes cross-references for \CEE/ identifiers */
-  eight_bits spec_ctrl@t\2\2@>)
+C_xref(/* makes cross-references for \CEE/ identifiers */
+  eight_bits spec_ctrl)
 {
   name_pointer p; /* a referenced name */
   while (next_control<format_code || next_control==spec_ctrl) {
@@ -1364,9 +1364,9 @@ static void finish_line(void);
 
 @ @c
 static void
-flush_buffer(@t\1\1@>
+flush_buffer(
 char *b, /* outputs from |out_buf+1| to |b|, where |b<=out_ptr| */
-boolean per_cent,boolean carryover@t\2\2@>)
+boolean per_cent,boolean carryover)
 {
   char *j; j=b; /* pointer into |out_buf| */
   if (! per_cent) /* remove trailing blanks */
@@ -1429,8 +1429,8 @@ static void break_out(void);
 
 @ @c
 static void
-out_str(@t\1\1@> /* output characters from |s| to end of string */
-const char*s@t\2\2@>)
+out_str(/* output characters from |s| to end of string */
+const char*s)
 {
   while (*s) out(*s++);
 }
@@ -1597,9 +1597,9 @@ one further token without overflow.
 @d app_tok(c) {if (tok_ptr+2>tok_mem_end) overflow("token"); *(tok_ptr++)=c;}
 
 @c
-static int copy_comment(@t\1\1@> /* copies \TeX\ code in comments */
+static int copy_comment(/* copies \TeX\ code in comments */
 boolean is_long_comment, /* is this a traditional \CEE/ comment? */
-int bal@t\2\2@>) /* brace balance */
+int bal) /* brace balance */
 {
   char c; /* current character being copied */
   while (true) {
@@ -1841,8 +1841,8 @@ static char cat_name[256][12];
 
 @c
 static void
-print_cat(@t\1\1@> /* symbolic printout of a category */
-eight_bits c@t\2\2@>)
+print_cat(/* symbolic printout of a category */
+eight_bits c)
 {
   fputs(cat_name[c],stdout);
 }
@@ -2225,8 +2225,8 @@ translated without line-break controls.
 
 @c
 static void
-print_text(@t\1\1@> /* prints a token list for debugging; not used in |main| */
-text_pointer p@t\2\2@>)
+print_text(/* prints a token list for debugging; not used in |main| */
+text_pointer p)
 {
   token_pointer j; /* index into |tok_mem| */
   sixteen_bits r; /* remainder of token after the flag has been stripped off */
@@ -2553,8 +2553,8 @@ the |for| loop below.
 
 @c
 static void
-make_reserved(@t\1\1@> /* make the first identifier in |p->trans| like |int| */
-scrap_pointer p@t\2\2@>)
+make_reserved(/* make the first identifier in |p->trans| like |int| */
+scrap_pointer p)
 {
   sixteen_bits tok_value; /* the name of this identifier, plus its flag */
   token_pointer tok_loc; /* pointer to |tok_value| */
@@ -2584,9 +2584,9 @@ it has been swallowed up by an |exp|.
 
 @c
 static void
-make_underlined(@t\1\1@>
+make_underlined(
 /* underline the entry for the first identifier in |p->trans| */
-scrap_pointer p@t\2\2@>)
+scrap_pointer p)
 {
   token_pointer tok_loc; /* where the first identifier appears */
   if ((tok_loc=find_first_ident(p->trans))<=operator_found)
@@ -3398,8 +3398,8 @@ is advanced.
 
 @c
 static void
-C_parse(@t\1\1@> /* creates scraps from \CEE/ tokens */
-  eight_bits spec_ctrl@t\2\2@>)
+C_parse(/* creates scraps from \CEE/ tokens */
+  eight_bits spec_ctrl)
 {
   int count; /* characters remaining before string break */
   while (next_control<format_code || next_control==spec_ctrl) {
@@ -3639,8 +3639,8 @@ static void outer_parse(void);
 
 @ @c
 static void
-app_cur_id(@t\1\1@>
-boolean scrapping@t\2\2@>) /* are we making this into a scrap? */
+app_cur_id(
+boolean scrapping) /* are we making this into a scrap? */
 {
   name_pointer p=id_lookup(id_first,id_loc,normal);
   if (p->ilk<=custom) { /* not a reserved word */
@@ -3806,8 +3806,8 @@ static void pop_level(void);
 
 @ @c
 static void
-push_level(@t\1\1@> /* suspends the current level */
-text_pointer p@t\2\2@>)
+push_level(/* suspends the current level */
+text_pointer p)
 {
   if (stack_ptr==stack_end) overflow("stack");
   if (stack_ptr>stack) { /* save current state */
@@ -4296,8 +4296,8 @@ takes place, so that the translation will normally end with \.{\\6} or
 
 @c
 static void
-finish_C(@t\1\1@> /* finishes a definition or a \CEE/ part */
-  boolean visible@t\2\2@>) /* |true| if we should produce \TeX\ output */
+finish_C(/* finishes a definition or a \CEE/ part */
+  boolean visible) /* |true| if we should produce \TeX\ output */
 {
   text_pointer p; /* translation of the scraps */
   if (visible) {
@@ -4475,8 +4475,8 @@ supply new definitions for the macros \.{\\A}, \.{\\As}, etc.
 
 @c
 static void
-footnote(@t\1\1@> /* outputs section cross-references */
-sixteen_bits flag@t\2\2@>)
+footnote(/* outputs section cross-references */
+sixteen_bits flag)
 {
   xref_pointer q; /* cross-reference pointer variable */
   if (cur_xref->num<=flag) return;
@@ -4717,8 +4717,8 @@ regarded as identical.
 
 @c
 static void
-unbucket(@t\1\1@> /* empties buckets having depth |d| */
-eight_bits d@t\2\2@>)
+unbucket(/* empties buckets having depth |d| */
+eight_bits d)
 {
   int c; /* index into |bucket|; cannot be a simple |char| because of sign
     comparison below */
@@ -4836,8 +4836,8 @@ prints them.
 
 @c
 static void
-section_print(@t\1\1@> /* print all section names in subtree |p| */
-name_pointer p@t\2\2@>)
+section_print(/* print all section names in subtree |p| */
+name_pointer p)
 {
   if (p) {
     section_print(p->llink); out_str("\\I");

--- a/cweave.w
+++ b/cweave.w
@@ -3079,8 +3079,8 @@ if (cat1==prelangle) squash(pp+1,1,langle,1,106);
 else if (cat1==colcol) squash(pp,2,colcol,-1,107);
 else if (cat1==cast) squash(pp,2,raw_int,0,108);
 else if (cat1==lpar) squash(pp,1,exp,-2,109);
-else if (cat1!=langle) squash(pp,1,int_like,-3,110);
 else if (cat1==lbrack) squash(pp,1,exp,-2,144);
+else if (cat1!=langle) squash(pp,1,int_like,-3,110);
 
 @ @<Cases for |operator_like|@>=
 if (cat1==binop || cat1==unop || cat1==ubinop) {
@@ -3462,10 +3462,10 @@ switch (next_control) {
   case xref_typewriter: case noop:@+break;
   case '(': app_str("\\1\\1");@+app(next_control);@+app_scrap(lpar,maybe_math);@+break;
 @.\\1@>
-    case '[': app(next_control);@+app_scrap(lbrack,maybe_math);@+break;
+  case '[': app(next_control);@+app_scrap(lbrack,maybe_math);@+break;
   case ')': app_str("\\2\\2");@+app(next_control);@+app_scrap(rpar,maybe_math);@+break;
 @.\\2@>
-    case ']': app(next_control);@+app_scrap(rbrack,maybe_math);@+break;
+  case ']': app(next_control);@+app_scrap(rbrack,maybe_math);@+break;
   case '{': app_str("\\{"@q}@>);@+app_scrap(lbrace,yes_math);@+break;
 @.\\\{@>@q}@>
   case '}': app_str(@q{@>"\\}");@+app_scrap(rbrace,yes_math);@+break;

--- a/cweave.w
+++ b/cweave.w
@@ -4435,18 +4435,12 @@ it starts after we scan the matching `\.)'.
   reswitch: switch (next_control=get_next()) {
       case '(': case ',': app(next_control); goto reswitch;
       case identifier: app_cur_id(false); goto reswitch;
-      case @q(@>')': app(next_control); next_control=get_next(); break;
-      case dot_dot_dot: app_str("\\,\\ldots\\,");
-@.\\,@>
-@.\\ldots@>
+      case ')': app(next_control); next_control=get_next(); break;
+      case dot_dot_dot: app_str("\\,\\ldots\\,"); @.\\,@> @.\\ldots@>
         app_scrap(raw_int,no_math);
-        next_control=get_next();
-        if (next_control==')') {
-          app(next_control);
-          next_control=get_next();
-          break;
-        }
-        /* otherwise fall through */
+        if ((next_control=get_next())==')') {
+          app(next_control); next_control=get_next(); break;
+        } /* otherwise fall through */
       default: err_print("! Improper macro definition"); break;
       }
       app('$');

--- a/cweave.w
+++ b/cweave.w
@@ -4348,18 +4348,12 @@ it starts after we scan the matching `\.)'.
   reswitch: switch (next_control=get_next()) {
       case '(': case ',': app(next_control); goto reswitch;
       case identifier: app_cur_id(false); goto reswitch;
-      case @q(@>')': app(next_control); next_control=get_next(); break;
-      case dot_dot_dot: app_str("\\,\\ldots\\,");
-@.\\,@>
-@.\\ldots@>
+      case ')': app(next_control); next_control=get_next(); break;
+      case dot_dot_dot: app_str("\\,\\ldots\\,"); @.\\,@> @.\\ldots@>
         app_scrap(raw_int,no_math);
-        next_control=get_next();
-        if (next_control==')') {
-          app(next_control);
-          next_control=get_next();
-          break;
-        }
-        /* otherwise fall through */
+        if ((next_control=get_next())==')') {
+          app(next_control); next_control=get_next(); break;
+        } /* otherwise fall through */
       default: err_print("! Improper macro definition"); break;
       }
       app('$');

--- a/cweave.w
+++ b/cweave.w
@@ -178,7 +178,7 @@ formatted.
 @d template_like 58 /* \&{template} */
 @d alignas_like 59 /* \&{alignas} */
 @d using_like 60 /* \&{using} */
-@d default_like 61 /* \&{using} */
+@d default_like 61 /* \&{default} */
 @d attr 62 /* \&{noexcept} and attributes */
 
 @ We keep track of the current section number in |section_count|, which

--- a/cweave.w
+++ b/cweave.w
@@ -2787,7 +2787,7 @@ else if (cat1==stmt || cat1==function) {
 @ @<Cases for |base|@>=
 if (cat1==int_like || cat1==exp) {
   if (cat2==comma) {
-    big_app1(pp); big_app(' '); big_app2(pp+1);
+    big_app1_insert(pp+1,' ');
     app(opt); app('9'); reduce(pp,3,base,0,42);
   }
   else if (cat2==lbrace) {
@@ -2978,7 +2978,7 @@ else if (cat1==rproc) {
   app(inserted); big_app2(pp); reduce(pp,2,insert,-1,79);
 } else if (cat1==exp || cat1==function) {
   if (cat2==rproc) {
-    app(inserted); big_app1(pp); big_app(' '); big_app2(pp+1);
+    app(inserted); big_app1_insert(pp+1,' ');
     reduce(pp,3,insert,-1,80);
   }
   else if (cat2==exp && cat3==rproc && cat1==exp) {

--- a/cweave.w
+++ b/cweave.w
@@ -3079,7 +3079,7 @@ squash(pp,1,int_like,-2,105);
 if (cat1==prelangle) squash(pp+1,1,langle,1,106);
 else if (cat1==colcol) squash(pp,2,colcol,-1,107);
 else if (cat1==cast) squash(pp,2,raw_int,0,108);
-else if (cat1==lpar||cat1==lbrack) squash(pp,1,exp,-2,109);
+else if (cat1==lpar) squash(pp,1,exp,-2,109);
 else if (cat1!=langle) squash(pp,1,int_like,-3,110);
 else if (cat1==lbrack) squash(pp,1,exp,-2,144);
 

--- a/cweave.w
+++ b/cweave.w
@@ -3474,7 +3474,6 @@ switch (next_control) {
   case '(': app(next_control);@+app_scrap(lpar,maybe_math);@+break;
   case ')': app(next_control);@+app_scrap(rpar,maybe_math);@+break;
   case '[': app(next_control);@+app_scrap(lbrack,maybe_math);@+break;
-  case '[': app(next_control);@+app_scrap(lbrack,maybe_math);@+break;
   case ']': app(next_control);@+app_scrap(rbrack,maybe_math);@+break;
   case '{': app_str("\\{"@q}@>);@+app_scrap(lbrace,yes_math);@+break;
 @.\\\{@>@q}@>

--- a/cweave.w
+++ b/cweave.w
@@ -2787,7 +2787,7 @@ else if (cat1==stmt || cat1==function) {
 @ @<Cases for |base|@>=
 if (cat1==int_like || cat1==exp) {
   if (cat2==comma) {
-    big_app1_insert(pp+1,' ');
+    big_app1(pp); big_app(' '); big_app2(pp+1);
     app(opt); app('9'); reduce(pp,3,base,0,42);
   }
   else if (cat2==lbrace) {
@@ -2978,7 +2978,7 @@ else if (cat1==rproc) {
   app(inserted); big_app2(pp); reduce(pp,2,insert,-1,79);
 } else if (cat1==exp || cat1==function) {
   if (cat2==rproc) {
-    app(inserted); big_app1_insert(pp+1,' ');
+    app(inserted); big_app1(pp); big_app(' '); big_app2(pp+1);
     reduce(pp,3,insert,-1,80);
   }
   else if (cat2==exp && cat3==rproc && cat1==exp) {
@@ -3472,6 +3472,7 @@ switch (next_control) {
 @.\\\#@>
   case ignore: case xref_roman: case xref_wildcard:
   case xref_typewriter: case noop:@+break;
+<<<<<<< HEAD
   case '(': app(next_control);@+app_scrap(lpar,maybe_math);@+break;
   case ')': app(next_control);@+app_scrap(rpar,maybe_math);@+break;
   case '[': app(next_control);@+app_scrap(lbrack,maybe_math);@+break;

--- a/cweave.w
+++ b/cweave.w
@@ -2669,7 +2669,7 @@ else if (cat1==cast && (cat2==const_like || cat2==case_like)) {
 }
 else if (cat1==exp || cat1==cast) squash(pp,2,exp,-2,10);
 else if (cat1==attr) {
-  big_app1(pp); big_app(' '); big_app1(pp+1);
+  big_app1_insert(pp+1,' ');
   reduce(pp,2,exp,-2,142);
 }
 else if (cat1==colcol && cat2==int_like) squash(pp,3,int_like,-2,152);
@@ -2765,7 +2765,7 @@ else if (cat1==lbrace || cat1==int_like || cat1==decl) {
 }
 else if (cat1==semi) squash(pp,2,decl,-1,39);
 else if (cat1==attr) {
-  big_app1(pp); big_app(' '); big_app1(pp+1);
+  big_app1_insert(pp+1,' ');
   reduce(pp,2,decl_head,-1,139);
 }
 
@@ -2780,11 +2780,11 @@ else if (cat1==stmt || cat1==function) {
 @ @<Cases for |base|@>=
 if (cat1==int_like || cat1==exp) {
   if (cat2==comma) {
-    big_app1(pp); big_app(' '); big_app2(pp+1);
+    big_app1_insert(pp+1,' ');
     app(opt); app('9'); reduce(pp,3,base,0,42);
   }
   else if (cat2==lbrace) {
-    big_app1(pp); big_app(' '); big_app1(pp+1); big_app(' '); big_app1(pp+2);
+    big_app1_insert(pp+1,' '); big_app(' '); big_app1(pp+2);
     reduce(pp,3,lbrace,-2,43);
   }
 }
@@ -2808,11 +2808,11 @@ else if (cat1==exp||cat1==int_like) {
   }
 }
 else if (cat1==attr) {
-  big_app1(pp); big_app(' '); big_app1(pp+1);
+  big_app1_insert(pp+1,' ');
   reduce(pp,2,struct_like,-3,141);
 }
 else if (cat1==struct_like) {
-  big_app1(pp); big_app(' '); big_app1(pp+1);
+  big_app1_insert(pp+1,' ');
   reduce(pp,2,struct_like,-3,151);
 }
 
@@ -2837,7 +2837,7 @@ else if (cat1==stmt) {
   big_app1(pp+1); reduce(pp,2,function,-1,52);
 }
 else if (cat1==attr) {
-  big_app1(pp); big_app(' '); big_app1(pp+1);
+  big_app1_insert(pp+1,' ');
   reduce(pp,2,fn_decl,0,157);
 }
 
@@ -2896,7 +2896,7 @@ else if (cat1==stmt) {
   else squash(pp,1,else_like,0,65);
 }
 else if (cat1==attr) {
-  big_app1(pp); big_app(' '); big_app1(pp+1);
+  big_app1_insert(pp+1,' ');
   reduce(pp,2,if_head,0,146);
 }
 
@@ -2971,7 +2971,7 @@ else if (cat1==rproc) {
   app(inserted); big_app2(pp); reduce(pp,2,insert,-1,79);
 } else if (cat1==exp || cat1==function) {
   if (cat2==rproc) {
-    app(inserted); big_app1(pp); big_app(' '); big_app2(pp+1);
+    app(inserted); big_app1_insert(pp+1,' ');
     reduce(pp,3,insert,-1,80);
   }
   else if (cat2==exp && cat3==rproc && cat1==exp) {
@@ -3043,7 +3043,7 @@ if (cat1==int_like || cat1==const_like) {
   big_app1_insert(pp,' '); reduce(pp,2,new_exp,0,95);
 }
 else if (cat1==struct_like && (cat2==exp || cat2==int_like)) {
-  big_app1(pp); big_app(' '); big_app1(pp+1); big_app(' ');
+  big_app1_insert(pp+1,' '); big_app(' ');
   big_app1(pp+2); reduce(pp,3,new_exp,0,96);
 }
 else if (cat1==raw_ubin) {
@@ -3156,29 +3156,29 @@ else if (cat1==comma)
 
 @ @<Cases for |attr|@>=
 if (cat1==lbrace || cat1==stmt) {
-  big_app1(pp); big_app(' '); big_app1(pp+1);
+  big_app1_insert(pp+1,' ');
   reduce(pp,2,cat1,-2,134);
 }
 else if (cat1==tag) {
-  big_app1(pp); big_app(' '); big_app1(pp+1);
+  big_app1_insert(pp+1,' ');
   reduce(pp,2,tag,-1,135);
 }
 else if (cat1==semi)
   squash(pp,2,stmt,-2,136);
 else if (cat1==attr) {
-  big_app1(pp); big_app(' '); big_app1(pp+1);
+  big_app1_insert(pp+1,' ');
   reduce(pp,2,attr,-1,137);
 }
 else if (cat1==decl_head) {
-  big_app1(pp); big_app(' '); big_app1(pp+1);
+  big_app1_insert(pp+1,' ');
   reduce(pp,2,decl_head,-1,138);
 }
 else if (cat1==typedef_like) {
-  big_app1(pp); big_app(' '); big_app1(pp+1);
+  big_app1_insert(pp+1,' ');
   reduce(pp,2,typedef_like,0,143);
 }
 else if (cat1==function) {
-  big_app1(pp); big_app(' '); big_app1(pp+1);
+  big_app1_insert(pp+1,' ');
   reduce(pp,2,function,-1,148);
 }
 

--- a/cweave.w
+++ b/cweave.w
@@ -143,7 +143,7 @@ will be typeset in special ways.
 \yskip\hang |typewriter| identifiers are index entries that appear after
 \.{@@.} in the \.{CWEB} file.
 
-\yskip\hang |alfop|, \dots, |template_like|
+\yskip\hang |alfop|, \dots, |attr|
 identifiers are \CEE/ or \CPLUSPLUS/ reserved words whose |ilk|
 explains how they are to be treated when \CEE/ code is being
 formatted.
@@ -824,7 +824,7 @@ with \TEX/ macros that the user can redefine to fit the context.
 In order to simplify such macros, we replace some of the characters.
 
 On output, the \.{\ } that replaces \.{'} in \CPLUSPLUS/ literals will become
-\.{\\\ }.
+``\.{\\\ }''.
 
 Notice that in this section and the next, |id_first| and |id_loc|
 are pointers into the array |section_text|, not into |buffer|.

--- a/cweave.w
+++ b/cweave.w
@@ -1957,11 +1957,14 @@ with discretionary breaks in between.
 \.{@@=}string\.{@@>}&|exp|: \.{\\vb\{}string with special characters
   quoted\.\}&maybe\cr
 \.{@@'7'}&|exp|: \.{\\.\{@@'7'\}}&maybe\cr
-\.{077} or \.{\\77}&|exp|: \.{\\T\{\\\~77\}}&maybe\cr
-\.{0x7f}&|exp|: \.{\\T\{\\\^7f\}}&maybe\cr
+\.{077} or \.{\\77}&|exp|: \.{\\T\{\\\~77/\}}&maybe\cr
+\.{0x7f}&|exp|: \.{\\T\{\\\^7f/\}}&maybe\cr
+\.{0b10111}&|exp|: \.{\\T\{\\\\10111/\}}&maybe\cr
 \.{77}&|exp|: \.{\\T\{77\}}&maybe\cr
 \.{77L}&|exp|: \.{\\T\{77\\\$L\}}&maybe\cr
 \.{0.1E5}&|exp|: \.{\\T\{0.1\\\_5\}}&maybe\cr
+\.{0x10p3}&|exp|: \.{\\T\{\\\^10/\\\%3\}}&maybe\cr
+\.{1'000'000}&|exp|: \.{\\T\{1\\\ 000\\\ 000\}}&maybe\cr
 \.+&|ubinop|: \.+&yes\cr
 \.-&|ubinop|: \.-&yes\cr
 \.*&|raw_ubin|: \.*&yes\cr

--- a/cweave.w
+++ b/cweave.w
@@ -176,6 +176,10 @@ formatted.
 @d typedef_like 56 /* \&{typedef} */
 @d define_like 57 /* \&{define} */
 @d template_like 58 /* \&{template} */
+@d alignas_like 59 /* \&{alignas} */
+@d using_like 60 /* \&{using} */
+@d default_like 61 /* \&{using} */
+@d attr 62 /* \&{noexcept} and attributes */
 
 @ We keep track of the current section number in |section_count|, which
 is the total number of sections that have started.  Sections which have
@@ -393,24 +397,44 @@ are defined in header files of the ISO Standard \CEE/ Library.)
 @^reserved words@>
 
 @<Store all the reserved words@>=
+id_lookup("alignas",NULL,alignas_like);
+id_lookup("_Alignas",NULL,alignas_like);
+id_lookup("alignof",NULL,sizeof_like);
+id_lookup("_Alignof",NULL,sizeof_like);
 id_lookup("and",NULL,alfop);
 id_lookup("and_eq",NULL,alfop);
 id_lookup("asm",NULL,sizeof_like);
+id_lookup("_Atomic",NULL,raw_int);
 id_lookup("auto",NULL,int_like);
 id_lookup("bitand",NULL,alfop);
 id_lookup("bitor",NULL,alfop);
 id_lookup("bool",NULL,raw_int);
+id_lookup("_Bool",NULL,raw_int);
 id_lookup("break",NULL,case_like);
 id_lookup("case",NULL,case_like);
 id_lookup("catch",NULL,catch_like);
 id_lookup("char",NULL,raw_int);
+id_lookup("char8_t",NULL,raw_int);
+id_lookup("char16_t",NULL,raw_int);
+id_lookup("char32_t",NULL,raw_int);
 id_lookup("class",NULL,struct_like);
 id_lookup("clock_t",NULL,raw_int);
+id_lookup("co_await",NULL,case_like);
 id_lookup("compl",NULL,alfop);
+id_lookup("_Complex",NULL,raw_int);
 id_lookup("const",NULL,const_like);
 id_lookup("const_cast",NULL,raw_int);
+id_lookup("consteval",NULL,const_like);
+id_lookup("constexpr",NULL,const_like);
+id_lookup("constinit",NULL,const_like);
 id_lookup("continue",NULL,case_like);
-id_lookup("default",NULL,case_like);
+id_lookup("co_return",NULL,case_like);
+id_lookup("co_yield",NULL,case_like);
+id_lookup("_Decimal128",NULL,raw_int);
+id_lookup("_Decimal32",NULL,raw_int);
+id_lookup("_Decimal64",NULL,raw_int);
+id_lookup("decltype",NULL,sizeof_like);
+id_lookup("default",NULL,default_like);
 id_lookup("define",NULL,define_like);
 id_lookup("defined",NULL,sizeof_like);
 id_lookup("delete",NULL,delete_like);
@@ -431,10 +455,12 @@ id_lookup("float",NULL,raw_int);
 id_lookup("for",NULL,for_like);
 id_lookup("fpos_t",NULL,raw_int);
 id_lookup("friend",NULL,int_like);
+id_lookup("_Generic",NULL,sizeof_like);
 id_lookup("goto",NULL,case_like);
 id_lookup("if",NULL,if_like);
 id_lookup("ifdef",NULL,if_like);
 id_lookup("ifndef",NULL,if_like);
+id_lookup("_Imaginary",NULL,raw_int);
 id_lookup("include",NULL,if_like);
 id_lookup("inline",NULL,int_like);
 id_lookup("int",NULL,raw_int);
@@ -445,9 +471,12 @@ id_lookup("long",NULL,raw_int);
 id_lookup("mutable",NULL,int_like);
 id_lookup("namespace",NULL,struct_like);
 id_lookup("new",NULL,new_like);
+id_lookup("noexcept",NULL,attr);
+id_lookup("_Noreturn",NULL,raw_int);
 id_lookup("not",NULL,alfop);
 id_lookup("not_eq",NULL,alfop);
 id_lookup("NULL",NULL,custom);
+id_lookup("nullptr",NULL,custom);
 id_lookup("offsetof",NULL,raw_int);
 id_lookup("operator",NULL,operator_like);
 id_lookup("or",NULL,alfop);
@@ -459,6 +488,7 @@ id_lookup("ptrdiff_t",NULL,raw_int);
 id_lookup("public",NULL,public_like);
 id_lookup("register",NULL,int_like);
 id_lookup("reinterpret_cast",NULL,raw_int);
+id_lookup("restrict",NULL,int_like);
 id_lookup("return",NULL,case_like);
 id_lookup("short",NULL,raw_int);
 id_lookup("sig_atomic_t",NULL,raw_int);
@@ -466,21 +496,25 @@ id_lookup("signed",NULL,raw_int);
 id_lookup("size_t",NULL,raw_int);
 id_lookup("sizeof",NULL,sizeof_like);
 id_lookup("static",NULL,int_like);
+id_lookup("static_assert",NULL,sizeof_like);
+id_lookup("_Static_assert",NULL,sizeof_like);
 id_lookup("static_cast",NULL,raw_int);
 id_lookup("struct",NULL,struct_like);
 id_lookup("switch",NULL,for_like);
 id_lookup("template",NULL,template_like);
 id_lookup("this",NULL,custom);
+id_lookup("thread_local",NULL,raw_int);
+id_lookup("_Thread_local",NULL,raw_int);
 id_lookup("throw",NULL,case_like);
 id_lookup("time_t",NULL,raw_int);
 id_lookup("try",NULL,else_like);
 id_lookup("typedef",NULL,typedef_like);
-id_lookup("typeid",NULL,raw_int);
+id_lookup("typeid",NULL,sizeof_like);
 id_lookup("typename",NULL,struct_like);
 id_lookup("undef",NULL,if_like);
 id_lookup("union",NULL,struct_like);
 id_lookup("unsigned",NULL,raw_int);
-id_lookup("using",NULL,int_like);
+id_lookup("using",NULL,using_like);
 id_lookup("va_dcl",NULL,decl); /* Berkeley's variable-arg-list convention */
 id_lookup("va_list",NULL,raw_int); /* ditto */
 id_lookup("virtual",NULL,int_like);
@@ -792,25 +826,50 @@ In order to simplify such macros, we replace some of the characters.
 Notice that in this section and the next, |id_first| and |id_loc|
 are pointers into the array |section_text|, not into |buffer|.
 
+@d gather_digits_while(t) while (t || *loc=='\'') {
+  if (*loc=='\'') { /* \CPLUSPLUS/-style digit separator */
+    *id_loc++=' '; /* insert a little bit of space */
+    loc++;
+  } else
+    *id_loc++=*loc++;
+}
+
 @<Get a constant@>= {
   id_first=id_loc=section_text+1;
+  if (*(loc-1)=='.' && !xisdigit(*loc)) goto mistake; /* not a constant */
   if (*(loc-1)=='0') {
-    if (*loc=='x' || *loc=='X') {*id_loc++='^'; loc++;
-      while (xisxdigit(*loc)) *id_loc++=*loc++;} /* hex constant */
-    else if (xisdigit(*loc)) {*id_loc++='~';
-      while (xisdigit(*loc)) *id_loc++=*loc++;} /* octal constant */
-    else goto dec; /* decimal constant */
-  }
-  else { /* decimal constant */
-    if (*(loc-1)=='.' && !xisdigit(*loc)) goto mistake; /* not a constant */
-    dec: *id_loc++=*(loc-1);
-    while (xisdigit(*loc) || *loc=='.') *id_loc++=*loc++;
-    if (*loc=='e' || *loc=='E') { /* float constant */
-      *id_loc++='_'; loc++;
-      if (*loc=='+' || *loc=='-') *id_loc++=*loc++;
-      while (xisdigit(*loc)) *id_loc++=*loc++;
+    if (*loc=='x' || *loc=='X') { /* hexadecimal constant */
+      *id_loc++='^';
+      loc++;
+      gather_digits_while(xisxdigit(*loc) || *loc=='.');
+      *id_loc++='/';
+      goto get_exponent;
+    } else if (*loc=='b' || *loc=='B') { /* binary constant */
+      *id_loc++='\\';
+      loc++;
+      gather_digits_while(*loc=='0' || *loc=='1');
+      *id_loc++='/';
+      goto digit_suffix;
+    }
+    else if (xisdigit(*loc)) {*id_loc++='~'; /* octal constant */
+      gather_digits_while(xisdigit(*loc));
+      *id_loc++='/';
+      goto digit_suffix;
     }
   }
+  *id_loc++=*(loc-1); /* decimal constant */
+  gather_digits_while(xisdigit(*loc) || *loc=='.');
+get_exponent:
+  if (*loc=='e' || *loc=='E')
+    *id_loc++='_';
+  else if (*loc=='p' || *loc=='P')
+    *id_loc++='%';
+  else
+    goto digit_suffix;
+  loc++;
+  if (*loc=='+' || *loc=='-') *id_loc++=*loc++;
+  gather_digits_while(xisdigit(*loc));
+digit_suffix:
   while (*loc=='u' || *loc=='U' || *loc=='l' || *loc=='L'
          || *loc=='f' || *loc=='F') {
     *id_loc++='$'; *id_loc++=toupper((eight_bits)*loc); loc++;
@@ -1675,8 +1734,8 @@ same initial letter; these subscripts are assigned from left to right.
 @d rbrace 8 /* denotes a right brace */
 @d decl_head 9 /* denotes an incomplete declaration */
 @d comma 10 /* denotes a comma */
-@d lpar 11 /* denotes a left parenthesis or left bracket */
-@d rpar 12 /* denotes a right parenthesis or right bracket */
+@d lpar 11 /* denotes a left parenthesis */
+@d rpar 12 /* denotes a right parenthesis */
 @d prelangle 13 /* denotes `$<$' before we know what it is */
 @d prerangle 14 /* denotes `$>$' before we know what it is */
 @d langle 15 /* denotes `$<$' when it's used as angle bracket in a template */
@@ -1698,10 +1757,13 @@ same initial letter; these subscripts are assigned from left to right.
 @d insert 37 /* a scrap that gets combined with its neighbor */
 @d section_scrap 38 /* section name */
 @d dead 39 /* scrap that won't combine */
-@d ftemplate 59 /* \\{make\_pair} */
-@d new_exp 60 /* \&{new} and a following type identifier */
-@d begin_arg 61 /* \.{@@[} */
-@d end_arg 62 /* \.{@@]} */
+@d ftemplate 63 /* \\{make\_pair} */
+@d new_exp 64 /* \&{new} and a following type identifier */
+@d begin_arg 65 /* \.{@@[} */
+@d end_arg 66 /* \.{@@]} */
+@d lbrack 67 /* \.{[} */
+@d rbrack 68 /* \.{]} */
+@d attr_head 69 /* denotes beginning of attribute */
 
 @<Private...@>=
 static char cat_name[256][12];
@@ -1766,6 +1828,13 @@ static char cat_name[256][12];
     strcpy(cat_name[new_exp],"new_exp");
     strcpy(cat_name[begin_arg],"@@["@q]@>);
     strcpy(cat_name[end_arg],@q[@>"@@]");
+    strcpy(cat_name[lbrack],"[");
+    strcpy(cat_name[rbrack],"]");
+    strcpy(cat_name[attr_head],"attr_head");
+    strcpy(cat_name[attr],"attr");
+    strcpy(cat_name[alignas_like],"alignas");
+    strcpy(cat_name[using_like],"using");
+    strcpy(cat_name[default_like],"default");
     strcpy(cat_name[0],"zero");
 
 @ This code allows \.{CWEAVE} to display its parsing steps.
@@ -1905,9 +1974,9 @@ with discretionary breaks in between.
 \.\~&|unop|: \.{\\CM}&yes\cr
 \.\&&|raw_ubin|: \.{\\AND}&yes\cr
 \.(&|lpar|: \.(&maybe\cr
-\.[&|lpar|: \.[&maybe\cr
 \.)&|rpar|: \.)&maybe\cr
-\.]&|rpar|: \.]&maybe\cr
+\.[&|lbrack|: \.[&maybe\cr
+\.]&|rbrack|: \.]&maybe\cr
 \.\{&|lbrace|: \.\{&yes\cr
 \.\}&|lbrace|: \.\}&yes\cr
 \.,&|comma|: \.,&yes\cr
@@ -1919,23 +1988,40 @@ end of \.\# line&|rproc|:  |force|&no\cr
 identifier&|exp|: \.{\\\\\{}identifier with underlines and
              dollar signs quoted\.\}&maybe\cr
 \.{and}&|alfop|: \stars&yes\cr
+\.{alignas}&|alignas_like|: \stars&maybe\cr
+\.{\_Alignas}&|alignas_like|: \stars&maybe\cr
+\.{alignof}&|sizeof_like|: \stars&maybe\cr
+\.{\_Alignof}&|sizeof_like|: \stars&maybe\cr
 \.{and\_eq}&|alfop|: \stars&yes\cr
 \.{asm}&|sizeof_like|: \stars&maybe\cr
+\.{\_Atomic}&|raw_int|: \stars&maybe\cr
 \.{auto}&|int_like|: \stars&maybe\cr
 \.{bitand}&|alfop|: \stars&yes\cr
 \.{bitor}&|alfop|: \stars&yes\cr
 \.{bool}&|raw_int|: \stars&maybe\cr
+\.{\_Bool}&|raw_int|: \stars&maybe\cr
 \.{break}&|case_like|: \stars&maybe\cr
 \.{case}&|case_like|: \stars&maybe\cr
 \.{catch}&|catch_like|: \stars&maybe\cr
 \.{char}&|raw_int|: \stars&maybe\cr
+\.{char8\_t}&|raw_int|: \stars&maybe\cr
+\.{char16\_t}&|raw_int|: \stars&maybe\cr
+\.{char32\_t}&|raw_int|: \stars&maybe\cr
 \.{class}&|struct_like|: \stars&maybe\cr
 \.{clock\_t}&|raw_int|: \stars&maybe\cr
 \.{compl}&|alfop|: \stars&yes\cr
+\.{\_Complex}&|raw_int|: \stars&maybe\cr
 \.{const}&|const_like|: \stars&maybe\cr
 \.{const\_cast}&|raw_int|: \stars&maybe\cr
+\.{consteval}&|const_like|: \stars&maybe\cr
+\.{constexpr}&|const_like|: \stars&maybe\cr
+\.{constinit}&|const_like|: \stars&maybe\cr
 \.{continue}&|case_like|: \stars&maybe\cr
-\.{default}&|case_like|: \stars&maybe\cr
+\.{\_Decimal128}&|raw_int|: \stars&maybe\cr
+\.{\_Decimal32}&|raw_int|: \stars&maybe\cr
+\.{\_Decimal64}&|raw_int|: \stars&maybe\cr
+\.{decltype}&|sizeof_like|: \stars&maybe\cr
+\.{default}&|default_like|: \stars&maybe\cr
 \.{define}&|define_like|: \stars&maybe\cr
 \.{defined}&|sizeof_like|: \stars&maybe\cr
 \.{delete}&|delete_like|: \stars&maybe\cr
@@ -1956,10 +2042,12 @@ identifier&|exp|: \.{\\\\\{}identifier with underlines and
 \.{for}&|for_like|: \stars&maybe\cr
 \.{fpos\_t}&|raw_int|: \stars&maybe\cr
 \.{friend}&|int_like|: \stars&maybe\cr
+\.{\_Generic}&|sizeof_like|: \stars&maybe\cr
 \.{goto}&|case_like|: \stars&maybe\cr
 \.{if}&|if_like|: \stars&maybe\cr
 \.{ifdef}&|if_like|: \stars&maybe\cr
 \.{ifndef}&|if_like|: \stars&maybe\cr
+\.{\_Imaginary}&|raw_int|: \stars&maybe\cr
 \.{include}&|if_like|: \stars&maybe\cr
 \.{inline}&|int_like|: \stars&maybe\cr
 \.{int}&|raw_int|: \stars&maybe\cr
@@ -1971,9 +2059,12 @@ identifier&|exp|: \.{\\\\\{}identifier with underlines and
 \.{mutable}&|int_like|: \stars&maybe\cr
 \.{namespace}&|struct_like|: \stars&maybe\cr
 \.{new}&|new_like|: \stars&maybe\cr
+\.{noexcept}&|attr|: \stars&maybe\cr
+\.{\_Noreturn}&|raw_int|: \stars&maybe\cr
 \.{not}&|alfop|: \stars&yes\cr
 \.{not\_eq}&|alfop|: \stars&yes\cr
 \.{NULL}&|exp|: \.{\\NULL}&yes\cr
+\.{nullptr}&|exp|: \.{\\NULL}&yes\cr
 \.{offsetof}&|raw_int|: \stars&maybe\cr
 \.{operator}&|operator_like|: \stars&maybe\cr
 \.{or}&|alfop|: \stars&yes\cr
@@ -1985,6 +2076,7 @@ identifier&|exp|: \.{\\\\\{}identifier with underlines and
 \.{public}&|public_like|: \stars&maybe\cr
 \.{register}&|int_like|: \stars&maybe\cr
 \.{reinterpret\_cast}&|raw_int|: \stars&maybe\cr
+\.{restrict}&|int_link|: \stars&maybe\cr
 \.{return}&|case_like|: \stars&maybe\cr
 \.{short}&|raw_int|: \stars&maybe\cr
 \.{sig\_atomic\_t}&|raw_int|: \stars&maybe\cr
@@ -1992,22 +2084,26 @@ identifier&|exp|: \.{\\\\\{}identifier with underlines and
 \.{size\_t}&|raw_int|: \stars&maybe\cr
 \.{sizeof}&|sizeof_like|: \stars&maybe\cr
 \.{static}&|int_like|: \stars&maybe\cr
+\.{static\_assert}&|sizeof_like|: \stars&maybe\cr
+\.{\_Static\_assert}&|sizeof_like|: \stars&maybe\cr
 \.{static\_cast}&|raw_int|: \stars&maybe\cr
 \.{struct}&|struct_like|: \stars&maybe\cr
 \.{switch}&|for_like|: \stars&maybe\cr
 \.{template}&|template_like|: \stars&maybe\cr
 \.{TeX}&|exp|: \.{\\TeX}&yes\cr
 \.{this}&|exp|: \.{\\this}&yes\cr
+\.{\_Thread\_local}&|raw_int|: \stars&maybe\cr
+\.{thread\_local}&|raw_int|: \stars&maybe\cr
 \.{throw}&|case_like|: \stars&maybe\cr
 \.{time\_t}&|raw_int|: \stars&maybe\cr
 \.{try}&|else_like|: \stars&maybe\cr
 \.{typedef}&|typedef_like|: \stars&maybe\cr
-\.{typeid}&|raw_int|: \stars&maybe\cr
+\.{typeid}&|sizeof_like|: \stars&maybe\cr
 \.{typename}&|struct_like|: \stars&maybe\cr
 \.{undef}&|if_like|: \stars&maybe\cr
 \.{union}&|struct_like|: \stars&maybe\cr
 \.{unsigned}&|raw_int|: \stars&maybe\cr
-\.{using}&|int_like|: \stars&maybe\cr
+\.{using}&|using_like|: \stars&maybe\cr
 \.{va\_dcl}&|decl|: \stars&maybe\cr
 \.{va\_list}&|raw_int|: \stars&maybe\cr
 \.{virtual}&|int_like|: \stars&maybe\cr
@@ -2313,7 +2409,7 @@ code needs to be provided with a proper environment.
 @d cat2 (pp+2)->cat
 @d cat3 (pp+3)->cat
 @d lhs_not_simple (pp->cat!=public_like
-        && pp->cat!=semi 
+        && pp->cat!=semi
         && pp->cat!=prelangle
         && pp->cat!=prerangle @|
         && pp->cat!=template_like
@@ -2330,6 +2426,8 @@ code needs to be provided with a proper environment.
   if (cat1==end_arg && lhs_not_simple)
     if (pp->cat==begin_arg) squash(pp,2,exp,-2,124);
     else squash(pp,2,end_arg,-1,125);
+  else if (pp->cat==rbrack) squash(pp,1,rpar,-3,130);
+  else if (pp->cat==using_like) squash(pp,1,int_like,-3,140);
   else if (cat1==insert) squash(pp,2,pp->cat,-2,0);
   else if (cat2==insert) squash(pp+1,2,(pp+1)->cat,-1,0);
   else if (cat3==insert) squash(pp+2,2,(pp+2)->cat,0,0);
@@ -2382,6 +2480,11 @@ code needs to be provided with a proper environment.
     case typedef_like: @<Cases for |typedef_like|@>@; @+break;
     case delete_like: @<Cases for |delete_like|@>@; @+break;
     case question: @<Cases for |question|@>@; @+break;
+    case alignas_like: @<Cases for |alignas_like|@>@; @+break;
+    case lbrack: @<Cases for |lbrack|@>@; @+break;
+    case attr_head: @<Cases for |attr_head|@>@; @+break;
+    case attr: @<Cases for |attr|@>@; @+break;
+    case default_like: @<Cases for |default_like|@>@; @+break;
   }
   pp++; /* if no match was found, we move to the right */
 }
@@ -2565,6 +2668,11 @@ else if (cat1==cast && (cat2==const_like || cat2==case_like)) {
   big_app1_insert(pp+1,' '); reduce(pp+1,2,cast,0,9);
 }
 else if (cat1==exp || cat1==cast) squash(pp,2,exp,-2,10);
+else if (cat1==attr) {
+  big_app1(pp); big_app(' '); big_app1(pp+1);
+  reduce(pp,2,exp,-2,142);
+}
+else if (cat1==colcol && cat2==int_like) squash(pp,3,int_like,-2,152);
 
 @ @<Cases for |lpar|@>=
 if ((cat1==exp||cat1==ubinop) && cat2==rpar) squash(pp,3,exp,-2,11);
@@ -2656,6 +2764,10 @@ else if (cat1==lbrace || cat1==int_like || cat1==decl) {
   big_app1(pp); big_app(indent); app(indent); reduce(pp,1,fn_decl,0,38);
 }
 else if (cat1==semi) squash(pp,2,decl,-1,39);
+else if (cat1==attr) {
+  big_app1(pp); big_app(' '); big_app1(pp+1);
+  reduce(pp,2,decl_head,-1,139);
+}
 
 @ @<Cases for |decl|@>=
 if (cat1==decl) {
@@ -2695,6 +2807,14 @@ else if (cat1==exp||cat1==int_like) {
     big_app1_insert(pp,' '); reduce(pp,2,int_like,-2,48);
   }
 }
+else if (cat1==attr) {
+  big_app1(pp); big_app(' '); big_app1(pp+1);
+  reduce(pp,2,struct_like,-3,141);
+}
+else if (cat1==struct_like) {
+  big_app1(pp); big_app(' '); big_app1(pp+1);
+  reduce(pp,2,struct_like,-3,151);
+}
 
 @ @<Cases for |struct_head|@>=
 if ((cat1==decl || cat1==stmt || cat1==function) && cat2==rbrace) {
@@ -2715,6 +2835,10 @@ if (cat1==decl) {
 else if (cat1==stmt) {
   big_app1(pp); app(outdent); app(outdent); big_app(force);
   big_app1(pp+1); reduce(pp,2,function,-1,52);
+}
+else if (cat1==attr) {
+  big_app1(pp); big_app(' '); big_app1(pp+1);
+  reduce(pp,2,fn_decl,0,157);
 }
 
 @ @<Cases for |function|@>=
@@ -2771,6 +2895,10 @@ else if (cat1==stmt) {
   }
   else squash(pp,1,else_like,0,65);
 }
+else if (cat1==attr) {
+  big_app1(pp); big_app(' '); big_app1(pp+1);
+  reduce(pp,2,if_head,0,146);
+}
 
 @ @<Cases for |if_head|@>=
 if (cat1==stmt || cat1==exp) {
@@ -2812,6 +2940,7 @@ else if (cat1==stmt||cat1==decl||cat1==function) {
   big_app1_insert(pp,break_space);
   reduce(pp,2,cat1,-1,75);
 }
+else squash(pp,1,decl,-1,156);
 
 @ The user can decide at run-time whether short statements should be
 grouped together on the same line.
@@ -2882,12 +3011,26 @@ else if (cat1==decl_head || cat1==int_like || cat1==exp) {
     big_app3(pp); app(opt); app('9'); reduce(pp,3,langle,0,88);
   }
 }
+else if (cat1==struct_like) {
+  if ((cat2==exp || cat2==int_like) && (cat3==comma || cat3==prerangle)) {
+    if (flags['t']) {
+      make_underlined(pp+2); make_reserved(pp+2);
+    }
+    big_app2(pp); big_app(' '); big_app2(pp+2);
+    if (cat3==comma) reduce(pp,4,langle,0,153);
+    else reduce(pp,4,cast,-1,154);
+  }
+}
 
 @ @<Cases for |template_like|@>=
 if (cat1==exp && cat2==prelangle) squash(pp+2,1,langle,2,89);
 else if (cat1==exp || cat1==raw_int) {
   big_app1_insert(pp,' '); reduce(pp,2,cat1,-2,90);
-}@+ else squash(pp,1,raw_int,0,91);
+}
+else if (cat1==cast && cat2==struct_like) {
+  big_app1_insert(pp,' '); reduce(pp,2,struct_like,0,155);
+}@+
+else squash(pp,1,raw_int,0,91);
 
 @ @<Cases for |new_like|@>=
 if (cat1==lpar && cat2==exp && cat3==rpar) squash(pp,4,new_like,0,92);
@@ -2936,8 +3079,9 @@ squash(pp,1,int_like,-2,105);
 if (cat1==prelangle) squash(pp+1,1,langle,1,106);
 else if (cat1==colcol) squash(pp,2,colcol,-1,107);
 else if (cat1==cast) squash(pp,2,raw_int,0,108);
-else if (cat1==lpar) squash(pp,1,exp,-2,109);
+else if (cat1==lpar||cat1==lbrack) squash(pp,1,exp,-2,109);
 else if (cat1!=langle) squash(pp,1,int_like,-3,110);
+else if (cat1==lbrack) squash(pp,1,exp,-2,144);
 
 @ @<Cases for |operator_like|@>=
 if (cat1==binop || cat1==unop || cat1==ubinop) {
@@ -2983,6 +3127,65 @@ if (cat1==exp && (cat2==colon || cat2==base)) {
   (pp+2)->mathness=5*yes_math; /* this colon should be in math mode */
   squash(pp,3,binop,-2,123);
 }
+
+@ @<Cases for |alignas_like|@>=
+if (cat1==decl_head)
+  squash(pp,2,attr,-1,126);
+else if (cat1==exp)
+  squash(pp,2,attr,-1,127);
+else if (cat1==cast)
+  squash(pp,2,attr,-1,158);
+
+@ @<Cases for |lbrack|@>=
+if (cat1==lbrack)
+  if (cat2==rbrack && cat3==rbrack)
+    squash(pp,4,exp,-2,147);
+  else squash(pp,2,attr_head,-1,128);
+else squash(pp,1,lpar,-1,129);
+
+@ @<Cases for |attr_head|@>=
+if (cat1==rbrack && cat2==rbrack)
+  squash(pp,3,attr,-1,131);
+else if (cat1==exp)
+  squash(pp,2,attr_head,0,132);
+else if (cat1==using_like && cat2==exp && cat3==colon) {
+  big_app2(pp); big_app(' '); big_app2(pp+2); big_app(' ');
+  reduce(pp,4,attr_head,0,133);
+}
+else if (cat1==comma)
+  squash(pp,2,attr_head,0,145);
+
+@ @<Cases for |attr|@>=
+if (cat1==lbrace || cat1==stmt) {
+  big_app1(pp); big_app(' '); big_app1(pp+1);
+  reduce(pp,2,cat1,-2,134);
+}
+else if (cat1==tag) {
+  big_app1(pp); big_app(' '); big_app1(pp+1);
+  reduce(pp,2,tag,-1,135);
+}
+else if (cat1==semi)
+  squash(pp,2,stmt,-2,136);
+else if (cat1==attr) {
+  big_app1(pp); big_app(' '); big_app1(pp+1);
+  reduce(pp,2,attr,-1,137);
+}
+else if (cat1==decl_head) {
+  big_app1(pp); big_app(' '); big_app1(pp+1);
+  reduce(pp,2,decl_head,-1,138);
+}
+else if (cat1==typedef_like) {
+  big_app1(pp); big_app(' '); big_app1(pp+1);
+  reduce(pp,2,typedef_like,0,143);
+}
+else if (cat1==function) {
+  big_app1(pp); big_app(' '); big_app1(pp+1);
+  reduce(pp,2,function,-1,148);
+}
+
+@ @<Cases for |default_like|@>=
+if (cat1==colon) squash(pp,2,case_like,-3,149);
+else squash(pp,1,exp,-2,150);
 
 @ Now here's the |reduce| procedure used in our code for productions.
 
@@ -3258,8 +3461,10 @@ switch (next_control) {
 @.\\\#@>
   case ignore: case xref_roman: case xref_wildcard:
   case xref_typewriter: case noop:@+break;
-  case '(': case '[': app(next_control);@+app_scrap(lpar,maybe_math);@+break;
-  case ')': case ']': app(next_control);@+app_scrap(rpar,maybe_math);@+break;
+  case '(': app(next_control);@+app_scrap(lpar,maybe_math);@+break;
+  case ')': app(next_control);@+app_scrap(rpar,maybe_math);@+break;
+  case '[': app(next_control);@+app_scrap(lbrack,maybe_math);@+break;
+  case ']': app(next_control);@+app_scrap(rbrack,maybe_math);@+break;
   case '{': app_str("\\{"@q}@>);@+app_scrap(lbrace,yes_math);@+break;
 @.\\\{@>@q}@>
   case '}': app_str(@q{@>"\\}");@+app_scrap(rbrace,yes_math);@+break;
@@ -4143,12 +4348,18 @@ it starts after we scan the matching `\.)'.
   reswitch: switch (next_control=get_next()) {
       case '(': case ',': app(next_control); goto reswitch;
       case identifier: app_cur_id(false); goto reswitch;
-      case ')': app(next_control); next_control=get_next(); break;
-      case dot_dot_dot: app_str("\\,\\ldots\\,"); @.\\,@> @.\\ldots@>
+      case @q(@>')': app(next_control); next_control=get_next(); break;
+      case dot_dot_dot: app_str("\\,\\ldots\\,");
+@.\\,@>
+@.\\ldots@>
         app_scrap(raw_int,no_math);
-        if ((next_control=get_next())==')') {
-          app(next_control); next_control=get_next(); break;
-        } /* otherwise fall through */
+        next_control=get_next();
+        if (next_control==')') {
+          app(next_control);
+          next_control=get_next();
+          break;
+        }
+        /* otherwise fall through */
       default: err_print("! Improper macro definition"); break;
       }
       app('$');

--- a/cweave.w
+++ b/cweave.w
@@ -823,6 +823,9 @@ introduced by \.0 and hexadecimals by \.{0x}, but \.{CWEAVE} will print
 with \TEX/ macros that the user can redefine to fit the context.
 In order to simplify such macros, we replace some of the characters.
 
+On output, the \.{\ } that replaces \.{'} in \CPLUSPLUS/ literals will become
+\.{\\\ }.
+
 Notice that in this section and the next, |id_first| and |id_loc|
 are pointers into the array |section_text|, not into |buffer|.
 
@@ -851,7 +854,8 @@ are pointers into the array |section_text|, not into |buffer|.
       *id_loc++='/';
       goto digit_suffix;
     }
-    else if (xisdigit(*loc)) {*id_loc++='~'; /* octal constant */
+    else if (xisdigit(*loc)) { /* octal constant */
+      *id_loc++='~';
       gather_digits_while(xisdigit(*loc));
       *id_loc++='/';
       goto digit_suffix;
@@ -1761,8 +1765,8 @@ same initial letter; these subscripts are assigned from left to right.
 @d new_exp 64 /* \&{new} and a following type identifier */
 @d begin_arg 65 /* \.{@@[} */
 @d end_arg 66 /* \.{@@]} */
-@d lbrack 67 /* \.{[} */
-@d rbrack 68 /* \.{]} */
+@d lbrack 67 /* denotes a left bracket */
+@d rbrack 68 /* denotes a right bracket */
 @d attr_head 69 /* denotes beginning of attribute */
 
 @<Private...@>=
@@ -2999,7 +3003,10 @@ app('<'); reduce(pp,1,binop,-2,84);
 init_mathness=cur_mathness=yes_math;
 app('>'); reduce(pp,1,binop,-2,85);
 
-@ @<Cases for |langle|@>=
+@ @d reserve_typenames flags['t']
+  /* should we treat \&{typename} in a template like \&{typedef}? */
+
+@<Cases for |langle|@>=
 if (cat1==prerangle) {
   big_app1(pp); app('\\'); app(','); big_app1(pp+1);
 @.\\,@>
@@ -3013,8 +3020,9 @@ else if (cat1==decl_head || cat1==int_like || cat1==exp) {
 }
 else if (cat1==struct_like) {
   if ((cat2==exp || cat2==int_like) && (cat3==comma || cat3==prerangle)) {
-    if (flags['t']) {
-      make_underlined(pp+2); make_reserved(pp+2);
+    make_underlined(pp+2);
+    if (reserve_typenames) {
+      make_reserved(pp+2);
     }
     big_app2(pp); big_app(' '); big_app2(pp+2);
     if (cat3==comma) reduce(pp,4,langle,0,153);

--- a/cwebmac.tex
+++ b/cwebmac.tex
@@ -343,10 +343,12 @@
 % \S is section sign
 \def\T#1{\leavevmode % octal, hex or decimal constant
   \hbox{$\def\?{\kern.2em}%
+    \def\ {\,}% extra space for digit separator
 %    \def\$##1{\egroup_{\,\rm##1}\bgroup}% suffix to constant % versions < 3.67
     \def\$##1{\egroup_{\rm##1}\bgroup}% suffix to constant % in version 3.67
     \def\_{\cdot 10^{\aftergroup}}% power of ten (via dirty trick)
-    \let\~=\oct \let\^=\hex {#1}$}}
+    \def\%{\cdot 10^{\aftergroup}}% power of sixteen (via dirty trick)
+    \let\~=\oct \let\^=\hex \let\\=\bin {#1}$}}
 \def\U{\note{This code is used in section}} % xref for use of a section
 \def\Us{\note{This code is used in sections}} % xref for uses of a section
 \let\V=\lor % logical or
@@ -365,8 +367,12 @@
 
 %\def\oct{\hbox{\rm\char'23\kern-.2em\it\aftergroup\?\aftergroup}} % WEB style
 %\def\hex{\hbox{\rm\char"7D\tt\aftergroup}} % WEB style
-\def\oct{\hbox{$^\circ$\kern-.1em\it\aftergroup\?\aftergroup}}% CWEB style
-\def\hex{\hbox{$^{\scriptscriptstyle\#}$\tt\aftergroup}} % CWEB style
+\def\oct{\hbox{$^\circ$\kern-.1em}\Od}% CWEB style
+\def\hex{\hbox{$^{\scriptscriptstyle\#}$}\Hd} % CWEB style
+\def\bin{\hbox{$^{\scriptscriptstyle b}$}\Bd}
+\def\Od#1/{{\it#1}} % octal digit
+\def\Hd#1/{{\tt#1}} % hexadecimal digit
+\def\Bd#1/{{\tt#1}} % binary digit
 \def\vb#1{\leavevmode\hbox{\kern2pt\vrule\vtop{\vbox{\hrule
         \hbox{\strut\kern2pt\.{#1}\kern2pt}}
       \hrule}\vrule\kern2pt}} % verbatim string

--- a/cwebmac.tex
+++ b/cwebmac.tex
@@ -348,7 +348,7 @@
 %    \def\$##1{\egroup_{\,\rm##1}\bgroup}% suffix to constant % versions < 3.67
     \def\$##1{\egroup_{\rm##1}\bgroup}% suffix to constant % in version 3.67
     \def\_{\cdot 10^{\aftergroup}}% power of ten (via dirty trick)
-    \def\%{\cdot 10^{\aftergroup}}% power of sixteen (via dirty trick)
+    \def\%{\cdot 16^{\aftergroup}}% power of sixteen (via dirty trick)
     \let\~=\oct \let\^=\hex \let\\=\bin {#1}$}}
 \def\U{\note{This code is used in section}} % xref for use of a section
 \def\Us{\note{This code is used in sections}} % xref for uses of a section

--- a/cwebmac.tex
+++ b/cwebmac.tex
@@ -341,9 +341,10 @@
 \def\Qs{\note{This code is cited in sections}} % xref for mentions of a section
 \let\R=\lnot % logical not
 % \S is section sign
+\def\digitseparator{\,} % a bit of extra space
 \def\T#1{\leavevmode % octal, hex or decimal constant
   \hbox{$\def\?{\kern.2em}%
-    \def\ {\,}% extra space for digit separator
+    \let\ \digitseparator%
 %    \def\$##1{\egroup_{\,\rm##1}\bgroup}% suffix to constant % versions < 3.67
     \def\$##1{\egroup_{\rm##1}\bgroup}% suffix to constant % in version 3.67
     \def\_{\cdot 10^{\aftergroup}}% power of ten (via dirty trick)

--- a/cwebman.tex
+++ b/cwebman.tex
@@ -477,9 +477,9 @@ respectively, to it; in \CEE/ the constant should be preceded by \.0
 or \.{0x}.  In \.{CWEB} it seems reasonable to let each convention hold
 in its respective realm; so in \CEE/ text you get $40_8$ by typing
 `\.{040}', which \.{CTANGLE} faithfully copies into the \CEE/ file (for
-the compiler's benefit) and which \.{CWEAVE} prints as $\T{\~40}$.
+the compiler's benefit) and which \.{CWEAVE} prints as $\T{\~40/}$.
 Similarly, \.{CWEAVE} prints the hexadecimal \CEE/ constant `\.{0x20}'
-as \T{\^20}. The use of italic font for octal digits and typewriter font
+as \T{\^20/}. The use of italic font for octal digits and typewriter font
 for hexadecimal digits makes the meaning of such constants clearer in
 a document. For consistency, then, you
 should type `\.{|040|}'  or `\.{|0x20|}'
@@ -761,11 +761,11 @@ and so on. When such characters occur in identifiers, \.{CTANGLE} must replace
 them by standard ASCII alphanumeric characters or
 \.{\_}, in order to generate legal \CEE/ code.  It does this by means
 of a transliteration table, which by default associates the string
-\.{Xab} to the character with ASCII code \T{\^}$ab$ (where $a$ and $b$ are
+\.{Xab} to the character with ASCII code \T{\^/}$ab$ (where $a$ and $b$ are
 hexadecimal digits, and $a\ge8$).  By placing the
 construction \.{@l\ ab\ newstring} in limbo, you are telling
 \.{CTANGLE} to replace this character by \.{newstring} instead.
-For example, the ISO Latin-1 code for the letter `\"u' is \T{\^FC}
+For example, the ISO Latin-1 code for the letter `\"u' is \T{\^FC/}
 (or \.{'\char`\\374'}),
 and \.{CTANGLE} will normally change this code to the
 three-character sequence \.{XFC} if it

--- a/my-changes.md
+++ b/my-changes.md
@@ -31,11 +31,6 @@ will be made a reserved word so that it acts like a type name.
 
 Quite a few new productions have been added to `prod.w`; they are all at the
 end, even though many of them would belong more logically earlier in the file.
-<<<<<<< 76a4f0af90fd9687d35e3edcf06ad1dc4067cf53
 There are new kinds of scrap as well, mostly for handling attributes.
 
 To test the major additions, run `CWEAVE` on `testthings.w`.
-=======
-There are new kinds of scrap as well, mostly for handling attributes. To test
-the major additions, run `CWEAVE` on `testthings.w`.
->>>>>>> Added new literals to CTANGLE

--- a/my-changes.md
+++ b/my-changes.md
@@ -24,3 +24,8 @@ template<typename N> class C { … };
 ```
 
 will be made a reserved word so that it acts like a type name.
+
+Quite a few new productions have been added to `prod.w`; they are all at the end, even
+though many of them would belong more logically earlier in the file. There are new kinds
+of scrap as well, mostly for handling attributes. To test the major additions, run
+`CWEAVE` on `testthings.w`.

--- a/my-changes.md
+++ b/my-changes.md
@@ -20,8 +20,8 @@ Made `typeid` act like `sizeof`.
 
 Added support for `enum class`, `enum struct`.
 
-Alter handling of `template` and `typename`.  If you supply the option `+t`, the
-identifier `N` in
+Altered handling of `template` and `typename`.  If you supply the option `+t`,
+the identifier `N` in
 
 ```C++
 template<typename N> class C { … };
@@ -31,5 +31,6 @@ will be made a reserved word so that it acts like a type name.
 
 Quite a few new productions have been added to `prod.w`; they are all at the
 end, even though many of them would belong more logically earlier in the file.
-There are new kinds of scrap as well, mostly for handling attributes. To test
-the major additions, run `CWEAVE` on `testthings.w`.
+There are new kinds of scrap as well, mostly for handling attributes.
+
+To test the major additions, run `CWEAVE` on `testthings.w`.

--- a/my-changes.md
+++ b/my-changes.md
@@ -1,16 +1,20 @@
-Added support for new C++ numeric literals. Note: The TeX side of this is rather jank.
-Currently, binary literals are formatted just like hexadecimal literals except with a
-superscript “b” instead of “#”.
+Added support for new C++ numeric literals. Note: The TeX side of this is rather
+jank. Currently, binary literals are formatted just like hexadecimal literals
+except with a superscript “b” instead of “#”, and the `'` digit separator
+becomes a thin space (`\,` in TeX). If you run `CTANGLE` with the option `+q`,
+it will omit the separator in output, so that you can use it in C code as well
+as in C++ code.
 
 Added support for C and C++ attributes.
 
 Allowed “`default;`” as a function body.
 
-Added more reserved words: `alignas`, `_Alignas`, `alignof`, `_Alignof`, `_Atomic`,
-`_Bool`, `char8_t`, `char16_t`, `char32_t`, `co_await`, `_Complex`, `consteval`,
-`constexpr`, `constinit`, `co_return`, `co_yield`, `_Decimal128`, `_Decimal32`,
-`_Decimal64`, `decltype`, `_Generic`, `_Imaginary`, `noexcept`, `_Noreturn`, `nullptr`,
-`static_assert`, `_Static_assert`, `thread_local`, `_Thread_local`.
+Added more reserved words: `alignas`, `_Alignas`, `alignof`, `_Alignof`,
+`_Atomic`, `_Bool`, `char8_t`, `char16_t`, `char32_t`, `co_await`, `_Complex`,
+`consteval`, `constexpr`, `constinit`, `co_return`, `co_yield`, `_Decimal128`,
+`_Decimal32`, `_Decimal64`, `decltype`, `_Generic`, `_Imaginary`, `noexcept`,
+`_Noreturn`, `nullptr`, `static_assert`, `_Static_assert`, `thread_local`,
+`_Thread_local`.
 
 Made `typeid` act like `sizeof`.
 
@@ -25,7 +29,7 @@ template<typename N> class C { … };
 
 will be made a reserved word so that it acts like a type name.
 
-Quite a few new productions have been added to `prod.w`; they are all at the end, even
-though many of them would belong more logically earlier in the file. There are new kinds
-of scrap as well, mostly for handling attributes. To test the major additions, run
-`CWEAVE` on `testthings.w`.
+Quite a few new productions have been added to `prod.w`; they are all at the
+end, even though many of them would belong more logically earlier in the file.
+There are new kinds of scrap as well, mostly for handling attributes. To test
+the major additions, run `CWEAVE` on `testthings.w`.

--- a/my-changes.md
+++ b/my-changes.md
@@ -1,7 +1,7 @@
 Added support for new C++ numeric literals. Note: The TeX side of this is rather
 jank. Currently, binary literals are formatted just like hexadecimal literals
 except with a superscript “b” instead of “#”, and the `'` digit separator
-becomes a thin space (`\,` in TeX). If you run `CTANGLE` with the option `+q`,
+becomes a thin space (`\,` in TeX). If you run `CTANGLE` with the option `+k`,
 it will omit the separator in output, so that you can use it in C code as well
 as in C++ code.
 

--- a/my-changes.md
+++ b/my-changes.md
@@ -1,0 +1,26 @@
+Added support for new C++ numeric literals. Note: The TeX side of this is rather jank.
+Currently, binary literals are formatted just like hexadecimal literals except with a
+superscript “b” instead of “#”.
+
+Added support for C and C++ attributes.
+
+Allowed “`default;`” as a function body.
+
+Added more reserved words: `alignas`, `_Alignas`, `alignof`, `_Alignof`, `_Atomic`,
+`_Bool`, `char8_t`, `char16_t`, `char32_t`, `co_await`, `_Complex`, `consteval`,
+`constexpr`, `constinit`, `co_return`, `co_yield`, `_Decimal128`, `_Decimal32`,
+`_Decimal64`, `decltype`, `_Generic`, `_Imaginary`, `noexcept`, `_Noreturn`, `nullptr`,
+`static_assert`, `_Static_assert`, `thread_local`, `_Thread_local`.
+
+Made `typeid` act like `sizeof`.
+
+Added support for `enum class`, `enum struct`.
+
+Alter handling of `template` and `typename`.  If you supply the option `+t`, the
+identifier `N` in
+
+```C++
+template<typename N> class C { … };
+```
+
+will be made a reserved word so that it acts like a type name.

--- a/my-changes.md
+++ b/my-changes.md
@@ -31,6 +31,11 @@ will be made a reserved word so that it acts like a type name.
 
 Quite a few new productions have been added to `prod.w`; they are all at the
 end, even though many of them would belong more logically earlier in the file.
+<<<<<<< 76a4f0af90fd9687d35e3edcf06ad1dc4067cf53
 There are new kinds of scrap as well, mostly for handling attributes.
 
 To test the major additions, run `CWEAVE` on `testthings.w`.
+=======
+There are new kinds of scrap as well, mostly for handling attributes. To test
+the major additions, run `CWEAVE` on `testthings.w`.
+>>>>>>> Added new literals to CTANGLE

--- a/prod.w
+++ b/prod.w
@@ -302,7 +302,7 @@ We use \\{in}, \\{out}, \\{back} and
 \+& |lbrack| |lbrack| |rbrack| |rbrack| & |exp| & |[[]]| \cr
 \+& |attr| |function| & |function| \hfill $A\.\ F$ &
   attribute and function \cr
-\+& |default_like| |colon| & |case_like| & |default:| \cr
+\+& |default_like| |colon| & |case_like| |colon| & |default:| \cr
 \+& |default_like| & |exp| & |f()=default;| \cr
 \+& |struct_like| |struct_like| & |struct_like| \hfill $S\.\ S$ &
   |enum class| \cr
@@ -314,7 +314,7 @@ We use \\{in}, \\{out}, \\{back} and
   \hbox{$\langle$\&{typename} $t\rangle$} \hss \cr
 \+& |template_like| |cast| |struct_like| & |struct_like| \hfill $T\.\ CS$ &
   |template<@t\dots@>> class| \cr
-\+& |tag| & |decl| & @q{@>|public: }| \cr
+\+& |tag| |rbrace| & |decl| & @q{@>|public: }| \cr
 \+& |fn_decl| |attr| & |fn_decl| \hfill $F\.\ A$ & |void f() noexcept| \cr
 \+& |alignas_like| |cast| & |attr| & |alignas(int)| \cr
 \yskip

--- a/prod.w
+++ b/prod.w
@@ -38,9 +38,9 @@ We use \\{in}, \\{out}, \\{back} and
 {$\displaystyle\Biggl\{\!\matrix{\strut\hbox{#1}\cr\hbox{#2}\cr
    \strut\hbox{#3}\cr}\!\Biggr\}$ }
 \def\malt #1 #2
-{$\displaystyle\matrix{\strut\hbox{#1}\hfill\cr\strut\hbox{#2}\hfill\cr}$}
+{$\displaystyle\!\matrix{\strut\hbox{#1}\hfill\cr\strut\hbox{#2}\hfill\cr}$}
 \def\maltt #1 #2 #3
-{$\displaystyle\matrix{\strut\hbox{#1}\hfill\cr\hbox{#2}\hfill\cr
+{$\displaystyle\!\matrix{\strut\hbox{#1}\hfill\cr\hbox{#2}\hfill\cr
    \strut\hbox{#3}\hfill\cr}$}
 \yskip
 \prodno=0 \midcol=2.5in
@@ -166,24 +166,24 @@ We use \\{in}, \\{out}, \\{back} and
 \+& |else_like| |colon| & |else_like| |base| & \&{try} :\cr
 \+& |else_like| |lbrace| & |else_head| |lbrace| & \&{else} $\{$\cr
 \+& |else_like| |stmt| & |stmt| \hfill
-       $|force|\,E\,\\{in}\,\\{bsp}\,S\,\\{out}\,|force|$ & |else x=0;|\cr
+       $|force|\,E\,\\{in}\,\\{bsp}\,S\,\\{out}\,|force|$ & $\!\!$|else x=0;|\cr
 \+& |else_head| \alt|stmt| |exp|  & |stmt| \hfill
-      $|force|\,E\,\\{bsp}\,|noop|\,|cancel|\,S\,\\{bsp}$ & |else{x=0;}|\cr
+      $|force|\,E\,\\{bsp}\,|noop|\,|cancel|\,S\,\\{bsp}$ & $\!\!$|else{x=0;}|\cr
 \+& |if_clause| |lbrace| & |if_head| |lbrace| & |if (x) {|\cr
 \+& |if_clause| |stmt| |else_like| |if_like| & |if_like| \hfill
     $|force|\,I\,\\{in}\,\\{bsp}\,S\,\\{out}\,|force|\,E\,\.\ I$ &
-     |if (x) y; else if|\cr
+     $\!\!$|if (x) y; else if|\cr
 \+& |if_clause| |stmt| |else_like| & |else_like| \hfill
     $|force|\,I\,\\{in}\,\\{bsp}\,S\,\\{out}\,|force|\,E$ &
-   |if (x) y; else|\cr
+   $\!\!$|if (x) y; else|\cr
 \+& |if_clause| |stmt| & |else_like| |stmt| & |if (x)|\cr
 \+& |if_head| \alt|stmt| |exp| |else_like| |if_like| & |if_like| \hfill
     $|force|\,I\,\\{bsp}\,|noop|\,|cancel|\,S\,|force|\,E\,\.\ I$ &
-     |if (x){y;}else if|\cr
+     $\!\!$|if (x){y;}else if|\cr
 \+& |if_head| \alt|stmt| |exp| |else_like| & |else_like| \hfill
     $|force|\,I\,\\{bsp}\,|noop|\,|cancel|\,S\,|force|\,E$ &
-   |if (x){y;}else|\cr
-\+& |if_head| \alt|stmt| |exp| & |else_head| \alt|stmt| |exp| & |if (x){y;}|\cr
+   $\!\!$|if (x){y;}else|\cr
+\+& |if_head| \alt|stmt| |exp| & |else_head| \alt|stmt| |exp| & $\!\!$|if (x){y;}|\cr
 \advance\midcol20pt
 \+& |do_like| |stmt| |else_like| |semi| & |stmt| \hfill
       $D\,\\{bsp}\,|noop|\,|cancel|\,S\,|cancel|\,|noop|\,\\{bsp}\,ES$%
@@ -196,18 +196,18 @@ We use \\{in}, \\{out}, \\{back} and
     $C$\alt $C$ $E$ \\{in}\,\\{in} & |catch (...)|\cr
 \+& |tag| |tag| & |tag| \hfill $T_1\,\\{bsp}\,T_2$ & |case 0: case 1:|\cr
 \+& |tag| \altt|stmt| |decl| |function| & \altt|stmt| |decl| |function|
-       \hfill $|force|\,\\{back}\,T\,\\{bsp}\,S$ & |case 0: z=0;|\cr
+       \hfill $|force|\,\\{back}\,T\,\\{bsp}\,S$ & $\!\!$|case 0: z=0;|\cr
 \+\dagit& |stmt| \altt|stmt| |decl| |function| &
    \altt|stmt| |decl| |function|
       \hfill $S\,$\altt$|force|\,S$ $|big_force|\,D$ $|big_force|\,F$ &
       |x=1;y=2;|\cr
 \+& |semi| & |stmt| \hfill \.\ $S$& empty statement\cr
 \+\dagit& |lproc| \altt |if_like| |else_like| |define_like| & |lproc| &
-         \maltt {{\bf \#include}} {\bf\#else} {\bf\#define} \cr
-\+& |lproc| |rproc| & |insert| & {\bf\#endif} \cr
+         \maltt {\#\&{include}} \#\&{else} \#\&{define} \cr
+\+& |lproc| |rproc| & |insert| & \#\&{endif} \cr
 \+& |lproc| \alt {|exp| [|exp|]} |function| |rproc| & |insert| \hfill
     $I$\.\ \alt {$E{[\.{\ \\5}E]}$} {$F$} &
- \malt{{\bf\#define} $a$\enspace 1} {{\bf\#define} $a$\enspace$\{\,b;\,\}$} \cr
+ \malt{\#\&{define} $a$\enspace 1} {\#\&{define} $a$\enspace$\{\,b;\,\}$} \cr
 \+& |section_scrap| |semi| & |stmt|\hfill $MS$ |force|
    &$\langle\,$section name$\,\rangle$;\cr
 \+& |section_scrap| & |exp| &$\langle\,$section name$\,\rangle$\cr
@@ -281,8 +281,8 @@ We use \\{in}, \\{out}, \\{back} and
 \+& |lbrack| & |lpar| & |[| elsewhere \cr
 \+& |rbrack| & |rpar| & |]| elsewhere \cr
 \+& |attr_head| |rbrack| |rbrack| & |attr| & $[[\ldots]]$ \cr
-\+& |attr_head| |exp| & |attr_head| & |[[deprecated| \cr
-\+& |attr_head| |using_like| |exp| |colon| & |attr_head| & |[[using NS:| \cr
+\+& |attr_head| |exp| & |attr_head| & $[[$|deprecated| \cr
+\+& |attr_head| |using_like| |exp| |colon| & |attr_head| & $[[$|using NS:| \cr
 \+& |attr| \alt|lbrace| |stmt| & \alt|lbrace| |stmt| \hfill $A\.\ $ \alt $S$ $L$ &
   |[[likely]] {|\cr
 \+& |attr| |tag| & |tag| \hfill $A\.\ T$ & |[[likely]] case 0:| \cr
@@ -297,7 +297,7 @@ We use \\{in}, \\{out}, \\{back} and
 \+& |attr| |typedef_like| & |typedef_like| \hfill $A\.\ T$ &
   |[[deprecated]] typedef| \cr
 \+& |raw_int| |lbrack| & |exp| & |int[3]| \cr
-\+& |attr_head| |comma| & |attr_head| & |[[x, y| \cr
+\+& |attr_head| |comma| & |attr_head| & $[[$|x, y| \cr
 \+& |if_head| |attr| & |if_head| \hfill $I\.\ A$ & |if (x) [[unlikely]] {| \cr
 \+& |lbrack| |lbrack| |rbrack| |rbrack| & |exp| & |[[]]| \cr
 \+& |attr| |function| & |function| \hfill $A\.\ F$ &

--- a/prod.w
+++ b/prod.w
@@ -38,9 +38,9 @@ We use \\{in}, \\{out}, \\{back} and
 {$\displaystyle\Biggl\{\!\matrix{\strut\hbox{#1}\cr\hbox{#2}\cr
    \strut\hbox{#3}\cr}\!\Biggr\}$ }
 \def\malt #1 #2
-{$\displaystyle\!\matrix{\strut\hbox{#1}\hfill\cr\strut\hbox{#2}\hfill\cr}$}
+{$\displaystyle\matrix{\strut\hbox{#1}\hfill\cr\strut\hbox{#2}\hfill\cr}$}
 \def\maltt #1 #2 #3
-{$\displaystyle\!\matrix{\strut\hbox{#1}\hfill\cr\hbox{#2}\hfill\cr
+{$\displaystyle\matrix{\strut\hbox{#1}\hfill\cr\hbox{#2}\hfill\cr
    \strut\hbox{#3}\hfill\cr}$}
 \yskip
 \prodno=0 \midcol=2.5in
@@ -161,24 +161,24 @@ We use \\{in}, \\{out}, \\{back} and
 \+& |else_like| |colon| & |else_like| |base| & \&{try} :\cr
 \+& |else_like| |lbrace| & |else_head| |lbrace| & \&{else} $\{$\cr
 \+& |else_like| |stmt| & |stmt| \hfill
-       $|force|\,E\,\\{in}\,\\{bsp}\,S\,\\{out}\,|force|$ & $\!\!$|else x=0;|\cr
+       $|force|\,E\,\\{in}\,\\{bsp}\,S\,\\{out}\,|force|$ & |else x=0;|\cr
 \+& |else_head| \alt|stmt| |exp|  & |stmt| \hfill
-      $|force|\,E\,\\{bsp}\,|noop|\,|cancel|\,S\,\\{bsp}$ & $\!\!$|else{x=0;}|\cr
+      $|force|\,E\,\\{bsp}\,|noop|\,|cancel|\,S\,\\{bsp}$ & |else{x=0;}|\cr
 \+& |if_clause| |lbrace| & |if_head| |lbrace| & |if (x) {|\cr
 \+& |if_clause| |stmt| |else_like| |if_like| & |if_like| \hfill
     $|force|\,I\,\\{in}\,\\{bsp}\,S\,\\{out}\,|force|\,E\,\.\ I$ &
-     $\!\!$|if (x) y; else if|\cr
+     |if (x) y; else if|\cr
 \+& |if_clause| |stmt| |else_like| & |else_like| \hfill
     $|force|\,I\,\\{in}\,\\{bsp}\,S\,\\{out}\,|force|\,E$ &
-   $\!\!$|if (x) y; else|\cr
+   |if (x) y; else|\cr
 \+& |if_clause| |stmt| & |else_like| |stmt| & |if (x)|\cr
 \+& |if_head| \alt|stmt| |exp| |else_like| |if_like| & |if_like| \hfill
     $|force|\,I\,\\{bsp}\,|noop|\,|cancel|\,S\,|force|\,E\,\.\ I$ &
-     $\!\!$|if (x){y;}else if|\cr
+     |if (x){y;}else if|\cr
 \+& |if_head| \alt|stmt| |exp| |else_like| & |else_like| \hfill
     $|force|\,I\,\\{bsp}\,|noop|\,|cancel|\,S\,|force|\,E$ &
-   $\!\!$|if (x){y;}else|\cr
-\+& |if_head| \alt|stmt| |exp| & |else_head| \alt|stmt| |exp| & $\!\!$|if (x){y;}|\cr
+   |if (x){y;}else|\cr
+\+& |if_head| \alt|stmt| |exp| & |else_head| \alt|stmt| |exp| & |if (x){y;}|\cr
 \advance\midcol20pt
 \+& |do_like| |stmt| |else_like| |semi| & |stmt| \hfill
       $D\,\\{bsp}\,|noop|\,|cancel|\,S\,|cancel|\,|noop|\,\\{bsp}\,ES$%
@@ -191,18 +191,18 @@ We use \\{in}, \\{out}, \\{back} and
     $C$\alt $C$ $E$ \\{in}\,\\{in} & |catch (...)|\cr
 \+& |tag| |tag| & |tag| \hfill $T_1\,\\{bsp}\,T_2$ & |case 0: case 1:|\cr
 \+& |tag| \altt|stmt| |decl| |function| & \altt|stmt| |decl| |function|
-       \hfill $|force|\,\\{back}\,T\,\\{bsp}\,S$ & $\!\!$|case 0: z=0;|\cr
+       \hfill $|force|\,\\{back}\,T\,\\{bsp}\,S$ & |case 0: z=0;|\cr
 \+\dagit& |stmt| \altt|stmt| |decl| |function| &
    \altt|stmt| |decl| |function|
       \hfill $S\,$\altt$|force|\,S$ $|big_force|\,D$ $|big_force|\,F$ &
       |x=1;y=2;|\cr
 \+& |semi| & |stmt| \hfill \.\ $S$& empty statement\cr
 \+\dagit& |lproc| \altt |if_like| |else_like| |define_like| & |lproc| &
-         \maltt {\#\&{include}} \#\&{else} \#\&{define} \cr
-\+& |lproc| |rproc| & |insert| & \#\&{endif} \cr
+         \maltt {{\bf \#include}} {\bf\#else} {\bf\#define} \cr
+\+& |lproc| |rproc| & |insert| & {\bf\#endif} \cr
 \+& |lproc| \alt {|exp| [|exp|]} |function| |rproc| & |insert| \hfill
     $I$\.\ \alt {$E{[\.{\ \\5}E]}$} {$F$} &
- \malt{\#\&{define} $a$\enspace 1} {\#\&{define} $a$\enspace$\{\,b;\,\}$} \cr
+ \malt{{\bf\#define} $a$\enspace 1} {{\bf\#define} $a$\enspace$\{\,b;\,\}$} \cr
 \+& |section_scrap| |semi| & |stmt|\hfill $MS$ |force|
    &$\langle\,$section name$\,\rangle$;\cr
 \+& |section_scrap| & |exp| &$\langle\,$section name$\,\rangle$\cr
@@ -270,6 +270,48 @@ We use \\{in}, \\{out}, \\{back} and
     \malt |?x:| |?f():| \cr
 \+& |begin_arg| |end_arg| & |exp| & \.{@@[}\&{char}$*$\.{@@]}\cr
 \+& |any_other| |end_arg| & |end_arg| &    \&{char}$*$\.{@@]}\cr
+\+& |alignas_like| |decl_head| & |attr| & |alignas(struct s *)| \cr
+\+& |alignas_like| |exp| & |attr| & |alignas(8)| \cr
+\+& |lbrack| |lbrack| & |attr_head| & attribute begins \cr
+\+& |lbrack| & |lpar| & |[| elsewhere \cr
+\+& |rbrack| & |rpar| & |]| elsewhere \cr
+\+& |attr_head| |rbrack| |rbrack| & |attr| & $[[\ldots]]$ \cr
+\+& |attr_head| |exp| & |attr_head| & |[[deprecated| \cr
+\+& |attr_head| |using_like| |exp| |colon| & |attr_head| & |[[using NS:| \cr
+\+& |attr| \alt|lbrace| |stmt| & \alt|lbrace| |stmt| \hfill $A\.\ $ \alt $S$ $L$ &
+  |[[likely]] {|\cr
+\+& |attr| |tag| & |tag| \hfill $A\.\ T$ & |[[likely]] case 0:| \cr
+\+& |attr| |semi| & |stmt| & |[[fallthrough]];| \cr
+\+& |attr| |attr| & |attr| \hfill $A\.\ A$ & |alignas(x)| $[[\ldots]]$ \cr
+\+& |attr| |decl_head| & |decl_head| & |[[nodiscard]] f()| \cr
+\+& |decl_head| |attr| & |decl_head| & |(int x [[deprecated]])|\cr
+\+& |using_like| & |int_like| & \&{using} not in attributes \cr
+\+& |struct_like| |attr| & |struct_like| \hfill $S\.\ A$ &
+  |struct [[deprecated]]|\cr
+\+& |exp| |attr| & |attr| \hfill $E\.\ A$ & \&{enum} $\{x\ [[\ldots]]\}$ \cr
+\+& |attr| |typedef_like| & |typedef_like| \hfill $A\.\ T$ &
+  |[[deprecated]] typedef| \cr
+\+& |raw_int| |lbrack| & |exp| & |int[3]| \cr
+\+& |attr_head| |comma| & |attr_head| & |[[x, y| \cr
+\+& |if_head| |attr| & |if_head| \hfill $I\.\ A$ & |if (x) [[unlikely]] {| \cr
+\+& |lbrack| |lbrack| |rbrack| |rbrack| & |exp| & |[[]]| \cr
+\+& |attr| |function| & |function| \hfill $A\.\ F$ &
+  attribute and function \cr
+\+& |default_like| |colon| & |case_like| & |default:| \cr
+\+& |default_like| & |exp| & |f()=default;| \cr
+\+& |struct_like| |struct_like| & |struct_like| \hfill $S\.\ S$ &
+  |enum class| \cr
+\+& |exp| |colcol| |int_like| & |int_like| & |std::atomic| \cr
+\+& |langle| |struct_like| \alt |exp| |int_like| |comma| &
+  |langle| \hfill $LS$\alt $E^{**}$ $I^{**}$ $C$ & $\langle$\&{typename} $t,$\cr
+\+& |langle| |struct_like| \alt |exp| |int_like| |prerangle| &
+  |cast| \hfill $LS$\alt $E^{**}$ $I^{**}$ $P$ &
+  $\langle$\&{typename} $t\rangle$ \cr
+\+& |template_like| |cast| |struct_like| & |struct_like| \hfill $T\.\ CS$ &
+  |template<@t\dots@>> class| \cr
+\+& |tag| & |decl| & @q{@>|public: }| \cr
+\+& |fn_decl| |attr| & |fn_decl| \hfill $F\.\ A$ & |void f() noexcept| \cr
+\+& |alignas_like| |cast| & |attr| & |alignas(int)| \cr
 \yskip
 \yskip
 \yskip

--- a/prod.w
+++ b/prod.w
@@ -38,9 +38,9 @@ We use \\{in}, \\{out}, \\{back} and
 {$\displaystyle\Biggl\{\!\matrix{\strut\hbox{#1}\cr\hbox{#2}\cr
    \strut\hbox{#3}\cr}\!\Biggr\}$ }
 \def\malt #1 #2
-{$\displaystyle\matrix{\strut\hbox{#1}\hfill\cr\strut\hbox{#2}\hfill\cr}$}
+{$\displaystyle\!\matrix{\strut\hbox{#1}\hfill\cr\strut\hbox{#2}\hfill\cr}$}
 \def\maltt #1 #2 #3
-{$\displaystyle\matrix{\strut\hbox{#1}\hfill\cr\hbox{#2}\hfill\cr
+{$\displaystyle\!\matrix{\strut\hbox{#1}\hfill\cr\hbox{#2}\hfill\cr
    \strut\hbox{#3}\hfill\cr}$}
 \yskip
 \prodno=0 \midcol=2.5in
@@ -51,6 +51,9 @@ We use \\{in}, \\{out}, \\{back} and
   \ifx\next\empty\theprodno\else\next\fi}\strut
   \ignorespaces#2\hfil\hbox to\midcol{$\RA$
   \ignorespaces#3\hfil}\quad \hbox to1.45in{\ignorespaces#4\hfil}}}
+\def\specialline&#1&#2&#3\cr{\line{\hbox to 2em{\hss\theprodno}\strut
+  \ignorespaces#1\hfil}
+  \line{\hfil\hbox to\midcol{$\RA$\ignorespaces\hfil#2}\quad \hbox to1.45in{\ignorespaces#3\hfil}}}
 \+\relax & LHS & RHS \hfill Translation & Example\cr
 \yskip
 \+& \altt\\{any} {\\{any} \\{any}} {\\{any} \\{any} \\{any}}
@@ -161,24 +164,24 @@ We use \\{in}, \\{out}, \\{back} and
 \+& |else_like| |colon| & |else_like| |base| & \&{try} :\cr
 \+& |else_like| |lbrace| & |else_head| |lbrace| & \&{else} $\{$\cr
 \+& |else_like| |stmt| & |stmt| \hfill
-       $|force|\,E\,\\{in}\,\\{bsp}\,S\,\\{out}\,|force|$ & |else x=0;|\cr
+       $|force|\,E\,\\{in}\,\\{bsp}\,S\,\\{out}\,|force|$ & $\!\!$|else x=0;|\cr
 \+& |else_head| \alt|stmt| |exp|  & |stmt| \hfill
-      $|force|\,E\,\\{bsp}\,|noop|\,|cancel|\,S\,\\{bsp}$ & |else{x=0;}|\cr
+      $|force|\,E\,\\{bsp}\,|noop|\,|cancel|\,S\,\\{bsp}$ & $\!\!$|else{x=0;}|\cr
 \+& |if_clause| |lbrace| & |if_head| |lbrace| & |if (x) {|\cr
 \+& |if_clause| |stmt| |else_like| |if_like| & |if_like| \hfill
     $|force|\,I\,\\{in}\,\\{bsp}\,S\,\\{out}\,|force|\,E\,\.\ I$ &
-     |if (x) y; else if|\cr
+     $\!\!$|if (x) y; else if|\cr
 \+& |if_clause| |stmt| |else_like| & |else_like| \hfill
     $|force|\,I\,\\{in}\,\\{bsp}\,S\,\\{out}\,|force|\,E$ &
-   |if (x) y; else|\cr
+   $\!\!$|if (x) y; else|\cr
 \+& |if_clause| |stmt| & |else_like| |stmt| & |if (x)|\cr
 \+& |if_head| \alt|stmt| |exp| |else_like| |if_like| & |if_like| \hfill
     $|force|\,I\,\\{bsp}\,|noop|\,|cancel|\,S\,|force|\,E\,\.\ I$ &
-     |if (x){y;}else if|\cr
+     $\!\!$|if (x){y;}else if|\cr
 \+& |if_head| \alt|stmt| |exp| |else_like| & |else_like| \hfill
     $|force|\,I\,\\{bsp}\,|noop|\,|cancel|\,S\,|force|\,E$ &
-   |if (x){y;}else|\cr
-\+& |if_head| \alt|stmt| |exp| & |else_head| \alt|stmt| |exp| & |if (x){y;}|\cr
+   $\!\!$|if (x){y;}else|\cr
+\+& |if_head| \alt|stmt| |exp| & |else_head| \alt|stmt| |exp| & $\!\!$|if (x){y;}|\cr
 \advance\midcol20pt
 \+& |do_like| |stmt| |else_like| |semi| & |stmt| \hfill
       $D\,\\{bsp}\,|noop|\,|cancel|\,S\,|cancel|\,|noop|\,\\{bsp}\,ES$%
@@ -191,18 +194,18 @@ We use \\{in}, \\{out}, \\{back} and
     $C$\alt $C$ $E$ \\{in}\,\\{in} & |catch (...)|\cr
 \+& |tag| |tag| & |tag| \hfill $T_1\,\\{bsp}\,T_2$ & |case 0: case 1:|\cr
 \+& |tag| \altt|stmt| |decl| |function| & \altt|stmt| |decl| |function|
-       \hfill $|force|\,\\{back}\,T\,\\{bsp}\,S$ & |case 0: z=0;|\cr
+       \hfill $|force|\,\\{back}\,T\,\\{bsp}\,S$ & $\!\!$|case 0: z=0;|\cr
 \+\dagit& |stmt| \altt|stmt| |decl| |function| &
    \altt|stmt| |decl| |function|
       \hfill $S\,$\altt$|force|\,S$ $|big_force|\,D$ $|big_force|\,F$ &
       |x=1;y=2;|\cr
 \+& |semi| & |stmt| \hfill \.\ $S$& empty statement\cr
 \+\dagit& |lproc| \altt |if_like| |else_like| |define_like| & |lproc| &
-         \maltt {{\bf \#include}} {\bf\#else} {\bf\#define} \cr
-\+& |lproc| |rproc| & |insert| & {\bf\#endif} \cr
+         \maltt {\#\&{include}} \#\&{else} \#\&{define} \cr
+\+& |lproc| |rproc| & |insert| & \#\&{endif} \cr
 \+& |lproc| \alt {|exp| [|exp|]} |function| |rproc| & |insert| \hfill
     $I$\.\ \alt {$E{[\.{\ \\5}E]}$} {$F$} &
- \malt{{\bf\#define} $a$\enspace 1} {{\bf\#define} $a$\enspace$\{\,b;\,\}$} \cr
+ \malt{\#\&{define} $a$\enspace 1} {\#\&{define} $a$\enspace$\{\,b;\,\}$} \cr
 \+& |section_scrap| |semi| & |stmt|\hfill $MS$ |force|
    &$\langle\,$section name$\,\rangle$;\cr
 \+& |section_scrap| & |exp| &$\langle\,$section name$\,\rangle$\cr
@@ -276,8 +279,8 @@ We use \\{in}, \\{out}, \\{back} and
 \+& |lbrack| & |lpar| & |[| elsewhere \cr
 \+& |rbrack| & |rpar| & |]| elsewhere \cr
 \+& |attr_head| |rbrack| |rbrack| & |attr| & $[[\ldots]]$ \cr
-\+& |attr_head| |exp| & |attr_head| & |[[deprecated| \cr
-\+& |attr_head| |using_like| |exp| |colon| & |attr_head| & |[[using NS:| \cr
+\+& |attr_head| |exp| & |attr_head| & $[[$|deprecated| \cr
+\+& |attr_head| |using_like| |exp| |colon| & |attr_head| & $[[$|using NS:| \cr
 \+& |attr| \alt|lbrace| |stmt| & \alt|lbrace| |stmt| \hfill $A\.\ $ \alt $S$ $L$ &
   |[[likely]] {|\cr
 \+& |attr| |tag| & |tag| \hfill $A\.\ T$ & |[[likely]] case 0:| \cr
@@ -292,7 +295,7 @@ We use \\{in}, \\{out}, \\{back} and
 \+& |attr| |typedef_like| & |typedef_like| \hfill $A\.\ T$ &
   |[[deprecated]] typedef| \cr
 \+& |raw_int| |lbrack| & |exp| & |int[3]| \cr
-\+& |attr_head| |comma| & |attr_head| & |[[x, y| \cr
+\+& |attr_head| |comma| & |attr_head| & $[[$|x, y| \cr
 \+& |if_head| |attr| & |if_head| \hfill $I\.\ A$ & |if (x) [[unlikely]] {| \cr
 \+& |lbrack| |lbrack| |rbrack| |rbrack| & |exp| & |[[]]| \cr
 \+& |attr| |function| & |function| \hfill $A\.\ F$ &
@@ -301,12 +304,12 @@ We use \\{in}, \\{out}, \\{back} and
 \+& |default_like| & |exp| & |f()=default;| \cr
 \+& |struct_like| |struct_like| & |struct_like| \hfill $S\.\ S$ &
   |enum class| \cr
-\+& |exp| |colcol| |int_like| & |int_like| & |std::atomic| \cr
-\+& |langle| |struct_like| \alt |exp| |int_like| |comma| &
+\+& |exp| |colcol| |int_like| & |int_like| & $\\{std}\DC\&{atomic}$ \cr
+\specialline& |langle| |struct_like| \alt |exp| |int_like| |comma| &
   |langle| \hfill $LS$\alt $E^{**}$ $I^{**}$ $C$ & $\langle$\&{typename} $t,$\cr
-\+& |langle| |struct_like| \alt |exp| |int_like| |prerangle| &
+\specialline& |langle| |struct_like| \alt |exp| |int_like| |prerangle| &
   |cast| \hfill $LS$\alt $E^{**}$ $I^{**}$ $P$ &
-  $\langle$\&{typename} $t\rangle$ \cr
+  \hbox{$\langle$\&{typename} $t\rangle$} \hss \cr
 \+& |template_like| |cast| |struct_like| & |struct_like| \hfill $T\.\ CS$ &
   |template<@t\dots@>> class| \cr
 \+& |tag| & |decl| & @q{@>|public: }| \cr

--- a/prod.w
+++ b/prod.w
@@ -351,7 +351,7 @@ or |cast|.
 
 Rule 123: The mathness of the |colon| or |base| changes to `yes'.
 
-Rules 153, 154: |make_underlined| is called only if the \.{+t} option is given
+Rules 153, 154: |make_reserved| is called only if the \.{+t} option is given
 to \.{CWEAVE}.
 
 \endgroup

--- a/prod.w
+++ b/prod.w
@@ -51,9 +51,11 @@ We use \\{in}, \\{out}, \\{back} and
   \ifx\next\empty\theprodno\else\next\fi}\strut
   \ignorespaces#2\hfil\hbox to\midcol{$\RA$
   \ignorespaces#3\hfil}\quad \hbox to1.45in{\ignorespaces#4\hfil}}}
-\def\specialline&#1&#2&#3\cr{\line{\hbox to 2em{\hss\theprodno}\strut
-  \ignorespaces#1\hfil}
-  \line{\hfil\hbox to\midcol{$\RA$\ignorespaces\hfil#2}\quad \hbox to1.45in{\ignorespaces#3\hfil}}}
+\def\specialline#1&#2&#3&#4\cr{\def\next{#1}%
+ \line{\hbox to 2em{\hss\ifx\next\empty\theprodno\else\next\fi}\strut
+  \ignorespaces#2\hfil}
+  \line{\hfil\hbox to\midcol{$\RA$\ignorespaces\hfil#3}\quad
+  \hbox to1.45in{\ignorespaces#4\hfil}}}
 \+\relax & LHS & RHS \hfill Translation & Example\cr
 \yskip
 \+& \altt\\{any} {\\{any} \\{any}} {\\{any} \\{any} \\{any}}
@@ -305,9 +307,9 @@ We use \\{in}, \\{out}, \\{back} and
 \+& |struct_like| |struct_like| & |struct_like| \hfill $S\.\ S$ &
   |enum class| \cr
 \+& |exp| |colcol| |int_like| & |int_like| & $\\{std}\DC\&{atomic}$ \cr
-\specialline& |langle| |struct_like| \alt |exp| |int_like| |comma| &
+\specialline\dagit& |langle| |struct_like| \alt |exp| |int_like| |comma| &
   |langle| \hfill $LS$\alt $E^{**}$ $I^{**}$ $C$ & $\langle$\&{typename} $t,$\cr
-\specialline& |langle| |struct_like| \alt |exp| |int_like| |prerangle| &
+\specialline\dagit& |langle| |struct_like| \alt |exp| |int_like| |prerangle| &
   |cast| \hfill $LS$\alt $E^{**}$ $I^{**}$ $P$ &
   \hbox{$\langle$\&{typename} $t\rangle$} \hss \cr
 \+& |template_like| |cast| |struct_like| & |struct_like| \hfill $T\.\ CS$ &
@@ -348,5 +350,8 @@ Rule 117: The |exp| must not be immediately followed by |lpar|, |exp|,
 or |cast|.
 
 Rule 123: The mathness of the |colon| or |base| changes to `yes'.
+
+Rules 153, 154: |make_underlined| is called only if the \.{+t} option is given
+to \.{CWEAVE}.
 
 \endgroup

--- a/prod.w
+++ b/prod.w
@@ -314,7 +314,7 @@ We use \\{in}, \\{out}, \\{back} and
   \hbox{$\langle$\&{typename} $t\rangle$} \hss \cr
 \+& |template_like| |cast| |struct_like| & |struct_like| \hfill $T\.\ CS$ &
   |template<@t\dots@>> class| \cr
-\+& |tag| |rbrace| & |decl| & @q{@>|public: }| \cr
+\+& |tag| |rbrace| & |decl| |rbrace| & @q{@>|public: }| \cr
 \+& |fn_decl| |attr| & |fn_decl| \hfill $F\.\ A$ & |void f() noexcept| \cr
 \+& |alignas_like| |cast| & |attr| & |alignas(int)| \cr
 \yskip

--- a/prod.w
+++ b/prod.w
@@ -38,9 +38,9 @@ We use \\{in}, \\{out}, \\{back} and
 {$\displaystyle\Biggl\{\!\matrix{\strut\hbox{#1}\cr\hbox{#2}\cr
    \strut\hbox{#3}\cr}\!\Biggr\}$ }
 \def\malt #1 #2
-{$\displaystyle\!\matrix{\strut\hbox{#1}\hfill\cr\strut\hbox{#2}\hfill\cr}$}
+{$\displaystyle\matrix{\strut\hbox{#1}\hfill\cr\strut\hbox{#2}\hfill\cr}$}
 \def\maltt #1 #2 #3
-{$\displaystyle\!\matrix{\strut\hbox{#1}\hfill\cr\hbox{#2}\hfill\cr
+{$\displaystyle\matrix{\strut\hbox{#1}\hfill\cr\hbox{#2}\hfill\cr
    \strut\hbox{#3}\hfill\cr}$}
 \yskip
 \prodno=0 \midcol=2.5in
@@ -166,24 +166,24 @@ We use \\{in}, \\{out}, \\{back} and
 \+& |else_like| |colon| & |else_like| |base| & \&{try} :\cr
 \+& |else_like| |lbrace| & |else_head| |lbrace| & \&{else} $\{$\cr
 \+& |else_like| |stmt| & |stmt| \hfill
-       $|force|\,E\,\\{in}\,\\{bsp}\,S\,\\{out}\,|force|$ & $\!\!$|else x=0;|\cr
+       $|force|\,E\,\\{in}\,\\{bsp}\,S\,\\{out}\,|force|$ & |else x=0;|\cr
 \+& |else_head| \alt|stmt| |exp|  & |stmt| \hfill
-      $|force|\,E\,\\{bsp}\,|noop|\,|cancel|\,S\,\\{bsp}$ & $\!\!$|else{x=0;}|\cr
+      $|force|\,E\,\\{bsp}\,|noop|\,|cancel|\,S\,\\{bsp}$ & |else{x=0;}|\cr
 \+& |if_clause| |lbrace| & |if_head| |lbrace| & |if (x) {|\cr
 \+& |if_clause| |stmt| |else_like| |if_like| & |if_like| \hfill
     $|force|\,I\,\\{in}\,\\{bsp}\,S\,\\{out}\,|force|\,E\,\.\ I$ &
-     $\!\!$|if (x) y; else if|\cr
+     |if (x) y; else if|\cr
 \+& |if_clause| |stmt| |else_like| & |else_like| \hfill
     $|force|\,I\,\\{in}\,\\{bsp}\,S\,\\{out}\,|force|\,E$ &
-   $\!\!$|if (x) y; else|\cr
+   |if (x) y; else|\cr
 \+& |if_clause| |stmt| & |else_like| |stmt| & |if (x)|\cr
 \+& |if_head| \alt|stmt| |exp| |else_like| |if_like| & |if_like| \hfill
     $|force|\,I\,\\{bsp}\,|noop|\,|cancel|\,S\,|force|\,E\,\.\ I$ &
-     $\!\!$|if (x){y;}else if|\cr
+     |if (x){y;}else if|\cr
 \+& |if_head| \alt|stmt| |exp| |else_like| & |else_like| \hfill
     $|force|\,I\,\\{bsp}\,|noop|\,|cancel|\,S\,|force|\,E$ &
-   $\!\!$|if (x){y;}else|\cr
-\+& |if_head| \alt|stmt| |exp| & |else_head| \alt|stmt| |exp| & $\!\!$|if (x){y;}|\cr
+   |if (x){y;}else|\cr
+\+& |if_head| \alt|stmt| |exp| & |else_head| \alt|stmt| |exp| & |if (x){y;}|\cr
 \advance\midcol20pt
 \+& |do_like| |stmt| |else_like| |semi| & |stmt| \hfill
       $D\,\\{bsp}\,|noop|\,|cancel|\,S\,|cancel|\,|noop|\,\\{bsp}\,ES$%
@@ -196,18 +196,18 @@ We use \\{in}, \\{out}, \\{back} and
     $C$\alt $C$ $E$ \\{in}\,\\{in} & |catch (...)|\cr
 \+& |tag| |tag| & |tag| \hfill $T_1\,\\{bsp}\,T_2$ & |case 0: case 1:|\cr
 \+& |tag| \altt|stmt| |decl| |function| & \altt|stmt| |decl| |function|
-       \hfill $|force|\,\\{back}\,T\,\\{bsp}\,S$ & $\!\!$|case 0: z=0;|\cr
+       \hfill $|force|\,\\{back}\,T\,\\{bsp}\,S$ & |case 0: z=0;|\cr
 \+\dagit& |stmt| \altt|stmt| |decl| |function| &
    \altt|stmt| |decl| |function|
       \hfill $S\,$\altt$|force|\,S$ $|big_force|\,D$ $|big_force|\,F$ &
       |x=1;y=2;|\cr
 \+& |semi| & |stmt| \hfill \.\ $S$& empty statement\cr
 \+\dagit& |lproc| \altt |if_like| |else_like| |define_like| & |lproc| &
-         \maltt {\#\&{include}} \#\&{else} \#\&{define} \cr
-\+& |lproc| |rproc| & |insert| & \#\&{endif} \cr
+         \maltt {{\bf \#include}} {\bf\#else} {\bf\#define} \cr
+\+& |lproc| |rproc| & |insert| & {\bf\#endif} \cr
 \+& |lproc| \alt {|exp| [|exp|]} |function| |rproc| & |insert| \hfill
     $I$\.\ \alt {$E{[\.{\ \\5}E]}$} {$F$} &
- \malt{\#\&{define} $a$\enspace 1} {\#\&{define} $a$\enspace$\{\,b;\,\}$} \cr
+ \malt{{\bf\#define} $a$\enspace 1} {{\bf\#define} $a$\enspace$\{\,b;\,\}$} \cr
 \+& |section_scrap| |semi| & |stmt|\hfill $MS$ |force|
    &$\langle\,$section name$\,\rangle$;\cr
 \+& |section_scrap| & |exp| &$\langle\,$section name$\,\rangle$\cr
@@ -281,8 +281,8 @@ We use \\{in}, \\{out}, \\{back} and
 \+& |lbrack| & |lpar| & |[| elsewhere \cr
 \+& |rbrack| & |rpar| & |]| elsewhere \cr
 \+& |attr_head| |rbrack| |rbrack| & |attr| & $[[\ldots]]$ \cr
-\+& |attr_head| |exp| & |attr_head| & $[[$|deprecated| \cr
-\+& |attr_head| |using_like| |exp| |colon| & |attr_head| & $[[$|using NS:| \cr
+\+& |attr_head| |exp| & |attr_head| & |[[deprecated| \cr
+\+& |attr_head| |using_like| |exp| |colon| & |attr_head| & |[[using NS:| \cr
 \+& |attr| \alt|lbrace| |stmt| & \alt|lbrace| |stmt| \hfill $A\.\ $ \alt $S$ $L$ &
   |[[likely]] {|\cr
 \+& |attr| |tag| & |tag| \hfill $A\.\ T$ & |[[likely]] case 0:| \cr
@@ -297,7 +297,7 @@ We use \\{in}, \\{out}, \\{back} and
 \+& |attr| |typedef_like| & |typedef_like| \hfill $A\.\ T$ &
   |[[deprecated]] typedef| \cr
 \+& |raw_int| |lbrack| & |exp| & |int[3]| \cr
-\+& |attr_head| |comma| & |attr_head| & $[[$|x, y| \cr
+\+& |attr_head| |comma| & |attr_head| & |[[x, y| \cr
 \+& |if_head| |attr| & |if_head| \hfill $I\.\ A$ & |if (x) [[unlikely]] {| \cr
 \+& |lbrack| |lbrack| |rbrack| |rbrack| & |exp| & |[[]]| \cr
 \+& |attr| |function| & |function| \hfill $A\.\ F$ &

--- a/testthings.w
+++ b/testthings.w
@@ -156,15 +156,7 @@ public:
 [[hal::daisy]] [[hal::rosie]] double nine999(double);
 [[hal::rosie]] [[hal::daisy]] double nine999(double);
 
-<<<<<<< d478924661945ebe86c5779e9e8645ff20a58ef1
-<<<<<<< 499476d26bc1d0bf8d450ce9dca27af2df4af951
 struct [[nodiscard]] error_info { /*\dots*/ };
-=======
-struct [[nodiscard]] error_info { /*...*/ };
->>>>>>> add testing file
-=======
-struct [[nodiscard]] error_info { /*\dots*/ };
->>>>>>> Simple updates following additional checking
 struct error_info enable_missile_safety_mode(void);
 void launch_missiles(void);
 void test_missiles(void) {

--- a/testthings.w
+++ b/testthings.w
@@ -1,0 +1,243 @@
+@s atomic int
+
+@* Attributes. This is just all of the examples from the sections about
+attributes in the \CEE/ and \CPLUSPLUS/ standards collected together, with most
+comments removed. If you watch parsing with \.{@@2} this whole section
+eventually gets reduced to a \.{function} scrap.
+
+@c
+[[using CC: opt(1), debug]]
+  void f() {}
+[[using CC: opt(1)]] [[CC::debug]]
+  void g() {}
+[[using CC: CC::opt(1)]]
+  void h() {}
+
+int p[10];
+void f() {
+  int x = 42, y[5];
+  int i [[vendor::attr([[]])]];
+}
+
+alignas(double) unsigned char c[sizeof(double)];
+extern unsigned char c[sizeof(double)];
+
+struct foo { int* a; int* b; };
+std::atomic<struct foo *> foo_head[10];
+
+int foo_array[10][10];
+
+[[carries_dependency]] struct foo* f(int i) {
+  return foo_head[i].load(memory_order::consume);
+}
+
+int g(int* x, int* y [[carries_dependency]]) {
+  return kill_dependency(foo_array[*x][*y]);
+}
+
+[[carries_dependency]] struct foo* f(int i);
+int g(int* x, int* y [[carries_dependency]]);
+
+int c = 3;
+
+void h(int i) {
+  struct foo* p;
+
+  p = f(i);
+  do_something_with(g(&c, p->a));
+  do_something_with(g(p->a, &c));
+}
+
+void f(int n) {
+  void g(), h(), i();
+  switch (n) {
+  case 1:
+  case 2:
+    g();
+    [[fallthrough]];
+  case 3:
+    do {
+      [[fallthrough]];
+    } while (false);
+  case 6:
+    do {
+      [[fallthrough]];
+    } while (n--);
+  case 7:
+    while (false) {
+      [[fallthrough]];
+    }
+  case 5:
+    h();
+  case 4:
+    i();
+    [[fallthrough]];
+  }
+}
+
+void g(int);
+int f(int n) {
+  if (n > 5) [[unlikely]] {
+    g(0);
+    return n * 2 + 1;
+  }
+
+  switch (n) {
+  case 1:
+    g(1);
+    [[fallthrough]];
+
+  [[likely]] case 2:
+    g(2);
+    break;
+  }
+  return 3;
+}
+
+[[maybe_unused]] void f([[maybe_unused]] bool thing1,
+                        [[maybe_unused]] bool thing2) {
+  [[maybe_unused]] bool b = thing1 && thing2;
+  assert(b);
+}
+
+struct [[nodiscard]] my_scopeguard { int x; };
+struct my_unique {
+  my_unique() = default;
+  [[nodiscard]] my_unique(int fd) { /* ... */ }
+  ~my_unique() noexcept { /* ... */ }
+  /* ... */
+};
+struct [[nodiscard]] error_info { /* ... */ };
+error_info enable_missile_safety_mode();
+void launch_missiles();
+void test_missiles() {
+  my_scopeguard();
+  (void)my_scopeguard(),
+    launch_missiles();
+  my_unique(42);
+  my_unique();
+  enable_missile_safety_mode();
+  launch_missiles();
+}
+error_info &foo();
+void f() { foo(); }
+
+
+[[ noreturn ]] void f() {
+  throw "error";
+}
+
+[[ noreturn ]] void q(int i) {
+  if (i > 0)
+    throw "positive";
+}
+
+template<typename Key, typename Value,
+         typename Hash, typename Pred, typename Allocator>
+class hash_map {
+  [[no_unique_address]] Hash hasher;
+  [[no_unique_address]] Pred pred;
+  [[no_unique_address]] Allocator alloc;
+  Bucket *buckets;
+
+public:
+
+};
+
+[[deprecated, hal::daisy]] double nine1000(double);
+[[deprecated]] [[hal::daisy]] double nine1000(double);
+[[deprecated]] double nine1000 [[hal::daisy]] (double);
+
+[[__deprecated__, __hal__::__daisy__]] double nine1000(double);
+[[__deprecated__]] [[__hal__::__daisy__]] double nine1000(double);
+[[__deprecated__]] double nine1000 [[__hal__::__daisy__]] (double);
+[[hal::daisy, hal::rosie]] double nine999(double);
+[[hal::rosie, hal::daisy]] double nine999(double);
+
+[[hal::daisy]] [[hal::rosie]] double nine999(double);
+[[hal::rosie]] [[hal::daisy]] double nine999(double);
+
+struct [[nodiscard]] error_info { /*...*/ };
+struct error_info enable_missile_safety_mode(void);
+void launch_missiles(void);
+void test_missiles(void) {
+enable_missile_safety_mode();
+launch_missiles();
+}
+
+[[nodiscard]] int important_func(void);
+void call(void) {
+int i = important_func();
+}
+
+[[nodiscard("must check armed state")]]
+bool arm_detonator(int);
+void call(void) {
+arm_detonator(3);
+detonate();
+}
+
+[[maybe_unused]] void f([[maybe_unused]] int i) {
+[[maybe_unused]] int j = i + 100;
+assert(j);
+}
+
+struct [[deprecated]] S {
+int a;
+};
+enum [[deprecated]] E1 {
+one
+};
+enum E2 {
+two [[deprecated("use ’three’ instead")]],
+three
+};
+[[deprecated]] typedef int Foo;
+void f1(struct S s) {
+int i = one;
+int j = two;
+int k = three;
+Foo f;
+}
+[[deprecated]] void f2(struct S s) {
+int i = one;
+int j = two;
+int k = three;
+Foo f;
+}
+struct [[deprecated]] T {
+Foo f;
+struct S s;
+};
+
+void f(int n) {
+void g(void), h(void), i(void);
+switch (n) {
+case 1: /* diagnostic on fallthrough discouraged */
+case 2:
+g();
+[[fallthrough]];
+case 3: /* diagnostic on fallthrough discouraged */
+h();
+case 4: /* fallthrough diagnostic encouraged */
+i();
+[[fallthrough]]; /* constraint violation */
+}
+}
+
+@* Numbers. Here are new numbers.
+
+@c
+
+int main(void)
+{
+  int decimal_integer = 100;
+  int octal_integer = 0240;
+  int binary_integer = 0b10101011;
+  int separated_integer = 100'000'000;
+  float binary_exponent = 0x1FFFFp10;
+  float separated_float = 123.456'789'000e2;
+  int normal_exponent = 123'456e789;
+}
+
+@* Index.

--- a/testthings.w
+++ b/testthings.w
@@ -102,19 +102,11 @@ int f(int n) {
 struct [[nodiscard]] my_scopeguard { int x; };
 struct my_unique {
   my_unique() = default;
-<<<<<<< 499476d26bc1d0bf8d450ce9dca27af2df4af951
   [[nodiscard]] my_unique(int fd) { /* \dots */ }
   ~my_unique() noexcept { /* \dots */ }
   /* \dots */
 };
 struct [[nodiscard]] error_info { /* \dots */ };
-=======
-  [[nodiscard]] my_unique(int fd) { /* ... */ }
-  ~my_unique() noexcept { /* ... */ }
-  /* ... */
-};
-struct [[nodiscard]] error_info { /* ... */ };
->>>>>>> add testing file
 error_info enable_missile_safety_mode();
 void launch_missiles();
 void test_missiles() {
@@ -164,11 +156,15 @@ public:
 [[hal::daisy]] [[hal::rosie]] double nine999(double);
 [[hal::rosie]] [[hal::daisy]] double nine999(double);
 
+<<<<<<< d478924661945ebe86c5779e9e8645ff20a58ef1
 <<<<<<< 499476d26bc1d0bf8d450ce9dca27af2df4af951
 struct [[nodiscard]] error_info { /*\dots*/ };
 =======
 struct [[nodiscard]] error_info { /*...*/ };
 >>>>>>> add testing file
+=======
+struct [[nodiscard]] error_info { /*\dots*/ };
+>>>>>>> Simple updates following additional checking
 struct error_info enable_missile_safety_mode(void);
 void launch_missiles(void);
 void test_missiles(void) {

--- a/testthings.w
+++ b/testthings.w
@@ -102,11 +102,19 @@ int f(int n) {
 struct [[nodiscard]] my_scopeguard { int x; };
 struct my_unique {
   my_unique() = default;
+<<<<<<< 499476d26bc1d0bf8d450ce9dca27af2df4af951
   [[nodiscard]] my_unique(int fd) { /* \dots */ }
   ~my_unique() noexcept { /* \dots */ }
   /* \dots */
 };
 struct [[nodiscard]] error_info { /* \dots */ };
+=======
+  [[nodiscard]] my_unique(int fd) { /* ... */ }
+  ~my_unique() noexcept { /* ... */ }
+  /* ... */
+};
+struct [[nodiscard]] error_info { /* ... */ };
+>>>>>>> add testing file
 error_info enable_missile_safety_mode();
 void launch_missiles();
 void test_missiles() {
@@ -156,7 +164,11 @@ public:
 [[hal::daisy]] [[hal::rosie]] double nine999(double);
 [[hal::rosie]] [[hal::daisy]] double nine999(double);
 
+<<<<<<< 499476d26bc1d0bf8d450ce9dca27af2df4af951
 struct [[nodiscard]] error_info { /*\dots*/ };
+=======
+struct [[nodiscard]] error_info { /*...*/ };
+>>>>>>> add testing file
 struct error_info enable_missile_safety_mode(void);
 void launch_missiles(void);
 void test_missiles(void) {

--- a/testthings.w
+++ b/testthings.w
@@ -2,8 +2,7 @@
 
 @* Attributes. This is just all of the examples from the sections about
 attributes in the \CEE/ and \CPLUSPLUS/ standards collected together, with most
-comments removed. If you watch parsing with \.{@@2} this whole section
-eventually gets reduced to a \.{function} scrap.
+comments removed.
 
 @c
 [[using CC: opt(1), debug]]

--- a/testthings.w
+++ b/testthings.w
@@ -102,11 +102,11 @@ int f(int n) {
 struct [[nodiscard]] my_scopeguard { int x; };
 struct my_unique {
   my_unique() = default;
-  [[nodiscard]] my_unique(int fd) { /* ... */ }
-  ~my_unique() noexcept { /* ... */ }
-  /* ... */
+  [[nodiscard]] my_unique(int fd) { /* \dots */ }
+  ~my_unique() noexcept { /* \dots */ }
+  /* \dots */
 };
-struct [[nodiscard]] error_info { /* ... */ };
+struct [[nodiscard]] error_info { /* \dots */ };
 error_info enable_missile_safety_mode();
 void launch_missiles();
 void test_missiles() {
@@ -156,7 +156,7 @@ public:
 [[hal::daisy]] [[hal::rosie]] double nine999(double);
 [[hal::rosie]] [[hal::daisy]] double nine999(double);
 
-struct [[nodiscard]] error_info { /*...*/ };
+struct [[nodiscard]] error_info { /*\dots*/ };
 struct error_info enable_missile_safety_mode(void);
 void launch_missiles(void);
 void test_missiles(void) {


### PR DESCRIPTION
(Github is saying “Can't automatically merge”, but I don't understand why.  It's showing me differences that I don't think actually exist. Oh well. Sorry for any inconvenience.)

A high-level summary of the changes is in `my-changes.md`. Two new command-line options have been added (`q` and `t`). **There have been breaking changes to `cwebmac.tex` that go along with `CWEAVE`'s new literal support**. It will not work with documents woven using previous versions. I am completely open to ideas for altering the constant-related macros to maintain backwards-compatibility.

The attribute stuff and the numeric stuff has been tested fairly thoroughly; all the code examples from the C and C++ standards work well. Other things are less tested, but they are conservative enough that problems should arise only in extreme cases, unless of course there are silly mistakes somewhere.

The sequence of statements

```C
big_app1(pp); big_app(' '); big_app1(pp+1);
```

occurs nearly twenty times; I would make it a macro, but there is no precedent for doing so in the other production-related code.

Speaking of productions, `prod.w` is now pretty weird-looking, since a few dozen new entries are appended with seemingly no logical order. In fact, they represent some of the debugging process; productions after 143 were added as I found problems with the previous set.

Further changes will likely be to add support for other C++ constructs, like `concept` and `requires`. (C++ has apparently grown quite a bit in the last few years.) The `#define`-related quirks might be looked at as well.