### PR TITLE
touchdone target to touch *.c

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,16 +143,19 @@ SAVEcommon.c:
 common.c: common.w $(CCHANGES) common.h
 	$(CTANGLE) common $(CCHANGES)
 
+touchdone:
+	touch *.c touchdone
+
 common.o: common.c
 	$(CC) $(CFLAGS) -DCWEBINPUTS=\"$(CWEBINPUTS)\" -c common.c
 
-ctangle: ctangle.o common.o
+ctangle: touchdone ctangle.o common.o
 	$(CC) $(LINKFLAGS) -o ctangle ctangle.o common.o
 
 ctangle.c: ctangle.w $(TCHANGES) common.h
 	$(CTANGLE) ctangle $(TCHANGES)
 
-cweave: cweave.o common.o
+cweave: touchdone cweave.o common.o
 	$(CC) $(LINKFLAGS) -o cweave cweave.o common.o
 
 cweave.c: cweave.w $(WCHANGES) common.h prod.w
@@ -175,7 +178,7 @@ fullmanual: usermanual $(SOURCES) comm-man.ch ctang-man.ch cweav-man.ch
 # be sure to leave ctangle.c and common.c for bootstrapping
 clean:
 	$(RM) -f -r *~ *.o common.tex cweave.tex cweave.c ctangle.tex \
-	  *.log *.dvi *.toc *.idx *.scn *.pdf *.hnt core cweave ctangle
+	  *.log *.dvi *.toc *.idx *.scn *.pdf *.hnt core cweave ctangle touchdone
 
 install: all
 	- mkdir $(DESTDIR)

--- a/README
+++ b/README
@@ -84,7 +84,7 @@ The files *-w32.ch use __fastcall conventions on win32 systems.
 The file comm-mac.ch is for Macintosh conventions.
 The other files named *.ch are sample change files for local customization.
 
-IMPORTANT: Please touch *.c before proceeding.
+IMPORTANT:
 Then edit the opening lines of Makefile so that it has the proper
 directory information for your local system.
 


### PR DESCRIPTION
Add `touchdone` target, to minimize manual steps such as "touch all *.c file first"